### PR TITLE
Fixed safes listing problem

### DIFF
--- a/tvaultui/src/app/Features/safes/safes.route.js
+++ b/tvaultui/src/app/Features/safes/safes.route.js
@@ -26,7 +26,7 @@
         parent: 'safes-tabs',
         params: {
           type: 'users',
-          fromLogin: false
+          fromLogin: true
         },
         resolve: {
           safes: function (SessionStore, $q, $state, safesService, $stateParams) {


### PR DESCRIPTION
Fix for: Safes are not getting listed if the permission is added as group