### PR TITLE
Quick Fix on Docker based installation and support for AWS Fargate

### DIFF
--- a/dist/src/main/docker/parameter
+++ b/dist/src/main/docker/parameter
@@ -15,6 +15,9 @@
 # See the readme.txt file for additional language around disclaimer of warranties.
 # =========================================================================			
 
+# To run docker without --privileged, use 'true' else 'false'
+SKIP_SETCAP='false'
+
 ###########################################################################
 #                            Auth Backend                                 #
 ###########################################################################

--- a/tvaultui/package.json
+++ b/tvaultui/package.json
@@ -39,7 +39,7 @@
     "gulp-replace": "~0.5.4",
     "gulp-rev": "~6.0.1",
     "gulp-rev-replace": "~0.4.2",
-    "gulp-sass": "~2.0.4",
+    "gulp-sass": "~3.1.0",
     "gulp-scss-lint": "^0.3.8",
     "gulp-shell": "^0.5.1",
     "gulp-size": "~2.0.0",


### PR DESCRIPTION
**Description**
Quick fix applied to fix the below issues,
1. https://github.com/tmobile/t-vault/issues/190
2. https://github.com/tmobile/t-vault/issues/191

Note: To run docker without --privileged option, Use, --cap-add=IPC_LOCK in docker run command and update the SKIP_SETCAP='true' in docker parameters