### PR TITLE
Added validation for the writeIAMKey API

### DIFF
--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/IAMServiceAccountKey.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/IAMServiceAccountKey.java
@@ -1,0 +1,164 @@
+package com.tmobile.cso.vault.api.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class IAMServiceAccountKey implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 3639469557176102034L;
+	
+	@Size(min = 16, max = 128, message = "AccessKeyId specified should be minimum 16 chanracters and maximum 128 characters only")
+	private String accessKeyId;
+	
+    private String accessKeySecret;
+	@NotNull
+	@Min(1)
+	private Long expiryDateEpoch;
+	@NotBlank
+	@Size(min = 1, max = 64, message = "UserName specified should be minimum 1 character and maximum 64 characters only")
+	@Pattern(regexp = "^[a-zA-Z0-9+=,.@_-]+$", message = "Name can have alphabets, numbers, plus (+), equal (=), comma (,), period (.), at (@), underscore (_), and hyphen (-)  only")
+    private String userName;
+	@NotBlank
+	@Pattern( regexp = "^$|^[0-9]+$", message="Invalid AWS account id")
+	@Size(min = 1, max = 12, message = "AWSAccountId specified should be maximum 12 characters only")
+    private String awsAccountId;
+    private String expiryDate;
+    private String createDate;
+    private String status;
+	/**
+	 * @return the accessKeyId
+	 */
+    @ApiModelProperty(example = "testaccesskeyid", position = 3)
+	public String getAccessKeyId() {
+		return accessKeyId;
+	}
+	/**
+	 * @return the accessKeySecret
+	 */
+    @ApiModelProperty(example = "", position = 4)
+	public String getAccessKeySecret() {
+		return accessKeySecret;
+	}
+	/**
+	 * @return the expiryDateEpoch
+	 */
+    @ApiModelProperty(example = "", position = 7)
+	public Long getExpiryDateEpoch() {
+		return expiryDateEpoch;
+	}
+	/**
+	 * @return the userName
+	 */
+	@ApiModelProperty(example = "testaccountname", position = 2)
+	public String getUserName() {
+		return userName;
+	}
+	/**
+	 * @return the awsAccountId
+	 */
+	@ApiModelProperty(example = "testaccountid", position = 1)
+	public String getAwsAccountId() {
+		return awsAccountId;
+	}
+	/**
+	 * @return the expiryDate
+	 */
+	@ApiModelProperty(example = "", position = 6)
+	public String getExpiryDate() {
+		return expiryDate;
+	}
+	/**
+	 * @return the createDate
+	 */
+	@ApiModelProperty(example = "", position = 5)
+	public String getCreateDate() {
+		return createDate;
+	}
+	/**
+	 * @return the status
+	 */
+	public String getStatus() {
+		return status;
+	}
+	/**
+	 * @param accessKeyId the accessKeyId to set
+	 */
+	public void setAccessKeyId(String accessKeyId) {
+		this.accessKeyId = accessKeyId;
+	}
+	/**
+	 * @param accessKeySecret the accessKeySecret to set
+	 */
+	public void setAccessKeySecret(String accessKeySecret) {
+		this.accessKeySecret = accessKeySecret;
+	}
+	/**
+	 * @param expiryDateEpoch the expiryDateEpoch to set
+	 */
+	public void setExpiryDateEpoch(Long expiryDateEpoch) {
+		this.expiryDateEpoch = expiryDateEpoch;
+	}
+	/**
+	 * @param userName the userName to set
+	 */
+	public void setUserName(String userName) {
+		this.userName = userName;
+	}
+	/**
+	 * @param awsAccountId the awsAccountId to set
+	 */
+	public void setAwsAccountId(String awsAccountId) {
+		this.awsAccountId = awsAccountId;
+	}
+	/**
+	 * @param expiryDate the expiryDate to set
+	 */
+	public void setExpiryDate(String expiryDate) {
+		this.expiryDate = expiryDate;
+	}
+	/**
+	 * @param createDate the createDate to set
+	 */
+	public void setCreateDate(String createDate) {
+		this.createDate = createDate;
+	}
+	/**
+	 * @param status the status to set
+	 */
+	public void setStatus(String status) {
+		this.status = status;
+	}
+	public IAMServiceAccountKey() {
+		
+	}
+	public IAMServiceAccountKey(String accessKeyId, String accessKeySecret, Long expiryDateEpoch, String userName,
+			String awsAccountId, String expiryDate, String createDate, String status) {
+		super();
+		this.accessKeyId = accessKeyId;
+		this.accessKeySecret = accessKeySecret;
+		this.expiryDateEpoch = expiryDateEpoch;
+		this.userName = userName;
+		this.awsAccountId = awsAccountId;
+		this.expiryDate = expiryDate;
+		this.createDate = createDate;
+		this.status = status;
+	}
+	@Override
+	public String toString() {
+		return "IAMServiceAccountKey [accessKeyId=" + accessKeyId + ", accessKeySecret=" + accessKeySecret
+				+ ", expiryDateEpoch=" + expiryDateEpoch + ", userName=" + userName + ", awsAccountId=" + awsAccountId
+				+ ", expiryDate=" + expiryDate + ", createDate=" + createDate + ", status=" + status + "]";
+	}
+    
+}

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/v2/controller/IAMServiceAccountsController.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/v2/controller/IAMServiceAccountsController.java
@@ -41,6 +41,7 @@ import com.tmobile.cso.vault.api.model.IAMServiceAccountAWSRole;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountAccessKey;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountApprole;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountGroup;
+import com.tmobile.cso.vault.api.model.IAMServiceAccountKey;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountOffboardRequest;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountRotateRequest;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountSecret;
@@ -392,7 +393,16 @@ public class IAMServiceAccountsController {
 	 */
 	@ApiOperation(value = "${IAMServiceAccountsController.writeKeys.value}", notes = "${IAMServiceAccountsController.writeKeys.notes}", hidden = false)
 	@PostMapping(value = "/v2/iam/iamserviceaccounts/keys", produces = "application/json")
-	public ResponseEntity<String> writeIAMKey(@RequestHeader(value = "vault-token") String token, @Valid @RequestBody IAMServiceAccountSecret iamServiceAccountSecret) throws IOException {
+	public ResponseEntity<String> writeIAMKey(@RequestHeader(value = "vault-token") String token, @Valid @RequestBody IAMServiceAccountKey iamServiceAccountKey) throws IOException {
+		IAMServiceAccountSecret iamServiceAccountSecret = new IAMServiceAccountSecret();
+		iamServiceAccountSecret.setAccessKeyId(iamServiceAccountKey.getAccessKeyId());
+		iamServiceAccountSecret.setAccessKeySecret(iamServiceAccountKey.getAccessKeySecret());
+		iamServiceAccountSecret.setExpiryDateEpoch(iamServiceAccountKey.getExpiryDateEpoch());
+		iamServiceAccountSecret.setUserName(iamServiceAccountKey.getUserName());
+		iamServiceAccountSecret.setAwsAccountId(iamServiceAccountKey.getAwsAccountId());
+		iamServiceAccountSecret.setExpiryDate(iamServiceAccountKey.getExpiryDate());
+		iamServiceAccountSecret.setCreateDate(iamServiceAccountKey.getCreateDate());
+		iamServiceAccountSecret.setStatus(iamServiceAccountKey.getStatus());
 		return iamServiceAccountsService.writeIAMKey(token, iamServiceAccountSecret);
 	}
 	

--- a/tvaultapi/src/main/resources/swaggernotes.properties
+++ b/tvaultapi/src/main/resources/swaggernotes.properties
@@ -1354,4 +1354,12 @@ SSLCertificateController.getFullCertificateList.value=To get list of certificate
 SSLCertificateController.getFullCertificateList.notes=<b>This API will fetch the list of certificates which the user has read/deny/owner permission. SearchText is optional.</b>
 
 IAMServiceAccountsController.writeKeys.value=To write IAM access key into vault
-IAMServiceAccountsController.writeKeys.notes=To write IAM access key into vault </b>
+IAMServiceAccountsController.writeKeys.notes=To write IAM access key into vault </b><br>\
+<b>userName: </b>UserName specified should be minimum 1 characters and maximum 64 characters and the allowed characters for UserName are  alphabets, numbers, '+', '=', comma, dot, '@', '__', '-' only. <br>\
+<b>awsAccountId: </b>AWS AccountId specified should be maximum 12 characters and allowed characters are from 0 to 9 only.<br>\
+<b>accessKeyId: </b>AccessKeyId specified should be minimum 16 characters and maximum 128 characters only.<br>\
+<b>accessKeySecret: </b>accessKeySecret is optional.<br>\
+<b>expiryDate: </b>expiryDate is optional <br>\
+<b>createDate: </b>createDate is optional <br>\
+<b>status: </b>status is optional <br>\
+<b>expiryDateEpoch: </b>Expiry Epoch cannot be null or empty.<br>\

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/v2/controller/IAMServiceAccountsControllerTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/v2/controller/IAMServiceAccountsControllerTest.java
@@ -50,7 +50,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tmobile.cso.vault.api.common.TVaultConstants;
@@ -61,9 +61,9 @@ import com.tmobile.cso.vault.api.model.IAMServiceAccountAWSRole;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountAccessKey;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountApprole;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountGroup;
+import com.tmobile.cso.vault.api.model.IAMServiceAccountKey;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountOffboardRequest;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountRotateRequest;
-import com.tmobile.cso.vault.api.model.IAMServiceAccountSecret;
 import com.tmobile.cso.vault.api.model.IAMServiceAccountUser;
 import com.tmobile.cso.vault.api.model.UserDetails;
 import com.tmobile.cso.vault.api.service.IAMServiceAccountsService;
@@ -583,14 +583,14 @@ public class IAMServiceAccountsControllerTest {
 	@Test
 	public void test_writeIAMKey() throws Exception {
 		String iamSvcaccName = "testaccount";
-		String awsAccountId = "1234567890";
-		String accessKeyId = "testaccesskey01";
+		String awsAccountId = "123456789012";
+		String accessKeyId = "testaccesskey011";
 		String accessKeySecret = "testsecret";
 		Long expiryDateEpoch = new Long(1627603345);
 		String createDate = "July 30, 2021 12:02:25 AM";
+		String expiryDate = "Oct 30, 2021 12:02:25 AM";
 		String status = "";
-		IAMServiceAccountSecret iamServiceAccount = new IAMServiceAccountSecret(iamSvcaccName, accessKeyId, accessKeySecret, expiryDateEpoch, awsAccountId, createDate, status);
-
+		IAMServiceAccountKey iamServiceAccount = new IAMServiceAccountKey(accessKeyId, accessKeySecret, expiryDateEpoch, iamSvcaccName, awsAccountId, expiryDate, createDate, status);
 		String inputJson = getJSON(iamServiceAccount);
 		String responseJson = "{\"messages\":[\"Successfully added accesskey for the IAM service account\"]}";
 		ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(responseJson);


### PR DESCRIPTION
Validations:
userName: UserName specified should be minimum 1 characters and maximum 64 characters and the allowed characters for UserName are alphabets, numbers, '+', '=', comma, dot, '@', '_', '-' only.
awsAccountId: AWSAccountId specified should be maximum 12 characters and allowed characters are from 0 to 9 only.
accessKeyId: AccessKeyId specified should be minimum 16 characters and maximum 128 characters only.
expiryDateEpoch: Expiry Epoch cannot be null or empty.
Swagger Notes for writeIAMKey API