### PR TITLE
Fix for issue related to downloading approle info

### DIFF
--- a/tvaultuiv2/src/views/private/vault-app-roles/components/ApproleDetails/index.js
+++ b/tvaultuiv2/src/views/private/vault-app-roles/components/ApproleDetails/index.js
@@ -256,7 +256,7 @@ const AppRoleDetails = (props) => {
               approle: appRoleDetail?.name,
               roleId: res.data.role_id,
               owner: res.data.appRoleMetadata.data.createdBy,
-              sharedTo: res.data.appRoleMetadata.data.sharedTo?.toString()?.replaceAll(/,/g, ' | '),
+              sharedTo: res.data.appRoleMetadata.data.sharedTo?.toString()?.replaceAll(/,/g, ' | ') || '',
               secretID: secretIdInfo?.secret_id,
               accessorID: secretIdInfo?.secret_id_accessor,
             },


### PR DESCRIPTION
Fix for approle issue where if the approle was made prior to recent changes the downloadable csv would be missing a field, shifting all other fields over one column. This fills that column with an empty string.