### PR TITLE
Updating API to get list of accesskeys for a given IAM Service Account

### DIFF
--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/IAMServiceAccountsService.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/IAMServiceAccountsService.java
@@ -477,14 +477,17 @@ public class  IAMServiceAccountsService {
 				List<String> identityPolicies = iamServiceAccountUtils.getIdentityPoliciesAsListFromTokenLookupJson(objectMapper, responseJson);
 				String readPolicyName = "r_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
 				String writePolicyName = "w_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
-				if (currentPolicies.contains(iamSelfSupportAdminPolicyName) || identityPolicies.stream().anyMatch((a) ->
-						a.startsWith(readPolicyName) || a.startsWith(writePolicyName))) {
-					log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder()
-							.put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER))
-							.put(LogMessage.ACTION, "isAuthorizedToReadAccessKeys")
-							.put(LogMessage.MESSAGE, "The User/Token has required policies to read access keys for IAM Service Account.")
-							.put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).build()));
-					return true;
+				String denyPolicyName = "d_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
+				if (!identityPolicies.contains(denyPolicyName)) {
+					if (currentPolicies.contains(iamSelfSupportAdminPolicyName) || identityPolicies.stream().anyMatch((policy) ->
+							policy.startsWith(readPolicyName) || policy.startsWith(writePolicyName))) {
+						log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder()
+								.put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER))
+								.put(LogMessage.ACTION, "isAuthorizedToReadAccessKeys")
+								.put(LogMessage.MESSAGE, "The User/Token has required policies to read access keys for IAM Service Account.")
+								.put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).build()));
+						return true;
+					}
 				}
 			} catch (IOException e) {
 				log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder()

--- a/tvaultapi/src/main/resources/swaggernotes.properties
+++ b/tvaultapi/src/main/resources/swaggernotes.properties
@@ -1174,7 +1174,7 @@ IAMServiceAccountsController.createAccessKeys.notes=<b>To create access key secr
 <b>iam_svc_name: </b>IAM Service Account name cannot be null or empty.
 
 IAMServiceAccountsController.getListOfIAMServiceAccountAccessKeys.value=To get all access keys for an IAM service account
-IAMServiceAccountsController.getListOfIAMServiceAccountAccessKeys.notes=<b>The users who have iamportal_admin_approle permissions can get the list of access keys </b><br>\
+IAMServiceAccountsController.getListOfIAMServiceAccountAccessKeys.notes=<b>Users who have the iamportal_admin_approle permission, or who have read/write access to the IAM Service Account can get the list of access keys. </b><br>\
 <b>aws_account_id: </b>AWS account id is required.<br>\
 <b>iam_svc_name: </b>IAM service account name is required.The service account name for which the secret to be read.<br>\
 

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/IAMServiceAccountServiceTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/IAMServiceAccountServiceTest.java
@@ -276,7 +276,7 @@ public class IAMServiceAccountServiceTest {
         when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
         when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
         ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.associateApproletoIAMsvcacc(userDetails, token, serviceAccountApprole);
 
         assertEquals(HttpStatus.OK, responseEntityActual.getStatusCode());
@@ -302,7 +302,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(tkn);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"testuser\",\"name\":\"svc_vault_test5\",\"users\":{\"testuser\":\"sudo\"}}}"));
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.associateApproletoIAMsvcacc(userDetails, tkn, serviceAccountApprole);
 
 		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntityActual.getStatusCode());
@@ -327,7 +327,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(tkn);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.associateApproletoIAMsvcacc(userDetails, tkn, serviceAccountApprole);
 
 		assertEquals(HttpStatus.BAD_REQUEST, responseEntityActual.getStatusCode());
@@ -357,7 +357,7 @@ public class IAMServiceAccountServiceTest {
 		List<String> currnetPolicies = new ArrayList<>();
 		currnetPolicies.add("iamportal_admin_policy");
 		when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(), Mockito.any())).thenReturn(currnetPolicies);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.associateApproletoIAMsvcacc(userDetails, token, serviceAccountApprole);
 
 		assertEquals(HttpStatus.OK, responseEntityActual.getStatusCode());
@@ -388,7 +388,7 @@ public class IAMServiceAccountServiceTest {
 		List<String> currnetPolicies = new ArrayList<>();
 		currnetPolicies.add("iamportal_admin_policy");
 		when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(), Mockito.any())).thenReturn(currnetPolicies);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.associateApproletoIAMsvcacc(userDetails, token, serviceAccountApprole);
 
 		assertEquals(HttpStatus.BAD_REQUEST, responseEntityActual.getStatusCode());
@@ -1277,57 +1277,6 @@ public class IAMServiceAccountServiceTest {
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.updateIAMServiceAccount(tkn,
 				userDetails, iamSvcAccTransfer);
 		String expectedResponse = "{\"errors\":[\"Update Failed. Owner_ntid is required when owner_email is given.\"]}";
-		ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.BAD_REQUEST).body(expectedResponse);
-		assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
-		assertEquals(responseEntityExpected, responseEntity);
-	}
-
-	@Test
-	public void test_updateIAMServiceAccount_null_iam_svc_acc_failure() throws Exception {
-		userDetails = getMockUser(true);
-		String tkn = userDetails.getClientToken();
-		IAMServiceAccount serviceAccount = generateIAMServiceAccount("testaccount", "1234567", "normaluser");
-		serviceAccount.setOwnerEmail("oldowner@email.com");
-		IAMServiceAccountTransfer iamSvcAccTransfer = new IAMServiceAccountTransfer(serviceAccount.getUserName(), serviceAccount.getAwsAccountId(),
-				"newowner", "newowner@t-mobile.com", null, null, null, null);
-
-		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testaccount\", \"awsAccountId\": \"1234567\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 12345, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": false, \"secret\":[{\"accessKeyId\":\"testaccesskey\", \"expiryDuration\":12345}]}, \"path\": \"iamsvcacc/1234567_testaccount\"}";
-
-		// Get metadata
-		String expectedMetadataBody = "{\"data\":{\"ad_group\":\"group1\",\"application_id\":\"app1\",\"application_name\":\"App1\"," +
-				"\"application_tag\":\"App1\",\"expiryDateEpoch\":\"99999\",\"expiryDuration\":\"1234\"," +
-				"\"awsAccountId\":\"1234567\",\"awsAccountName\":\"testaccount1\",\"createdAtEpoch\":12345,\"groups\":{\"group1\":\"write\"}," +
-				"\"isActivated\":true,\"owner_email\":\"normaluser@test.com\",\"owner_ntid\":\"normaluser\"," +
-				"\"secret\":[{\"accessKeyId\":\"123456789123456789\",\"expiryDateEpoch\":12345}],\"userName\":\"testaccount\"}}";
-		Response expectedMetadataResponse = getMockResponse(HttpStatus.NOT_FOUND, true, expectedMetadataBody);
-		when(reqProcessor.process(eq("/sdb"), Mockito.any(), eq(tkn))).thenReturn(expectedMetadataResponse);
-
-		String path = "metadata/iamsvcacc/1234567_testaccount";
-		when(reqProcessor.process("/read", "{\"path\":\""+path+"\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true,
-				iamMetaDataStr));
-
-		// Validations
-		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
-		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("iamportal_admin_policy");
-		try {
-			when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-
-		when(JSONUtil.getJSON(Mockito.any())).thenReturn("{\"shared\":[{\"s3\":\"read\"},{\"s4\":\"write\"}],\"users\":[{\"s1\":\"read\"},{\"s2\":\"write\"}],\"svcacct\":[{\"test\":\"read\"}],\"iamsvcacc\":[{\"test\":\"read\"}],\"apps\":[{\"s5\":\"read\"},{\"s6\":\"write\"},{\"s7\":\"deny\"}]}");
-		when(reqProcessor.process(eq("/iam/onboardedlist"), Mockito.any(), eq(tkn))).thenReturn(getMockResponse(
-				HttpStatus.OK, true, "{\"keys\":[\"1234567_testaccount\" ]}"));
-		when(JSONUtil.getJSON(Mockito.any())).thenReturn(
-				"{\"shared\":[{\"s3\":\"read\"},{\"s4\":\"write\"}],\"users\":[{\"s1\":\"read\"},{\"s2\":\"write\"}],\"svcacct\":[{\"test\":\"read\"}],\"iamsvcacc\":[{\"test\":\"sudo\"}],\"apps\":[{\"s5\":\"read\"},{\"s6\":\"write\"},{\"s7\":\"deny\"}]}");
-
-		PowerMockito.whenNew(IAMServiceAccount.class).withNoArguments().thenReturn(null);
-
-		ResponseEntity<String> responseEntity = iamServiceAccountsService.updateIAMServiceAccount(tkn,
-				userDetails, iamSvcAccTransfer);
-		String expectedResponse = "{\"errors\":[\"Failed to get metadata for this IAM Service Account.\"]}";
 		ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.BAD_REQUEST).body(expectedResponse);
 		assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
 		assertEquals(responseEntityExpected, responseEntity);
@@ -3298,7 +3247,7 @@ public class IAMServiceAccountServiceTest {
 				"{\"errors\":[\"Error Fetching existing IAM Service account info. please check the path specified\"]}");
 		when(tokenUtils.getSelfServiceToken()).thenReturn(token);
 		when(reqProcessor.process(eq("/sdb"), Mockito.any(), eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true,
-				"{\"data\":{\"isActivated\":false,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+				"{\"data\":{\"isActivated\":false,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 		String[] latestPolicies = { "o_iamsvcacc_1234567_testaccount" };
 		when(policyUtils.getCurrentPolicies(userDetails.getSelfSupportToken(), userDetails.getUsername(), userDetails))
 				.thenReturn(latestPolicies);
@@ -3616,7 +3565,7 @@ public class IAMServiceAccountServiceTest {
 	        when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeApproleFromIAMSvcAcc(userDetails, token, serviceAccountApprole);
 
@@ -3644,7 +3593,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(tkn);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeApproleFromIAMSvcAcc(userDetails, tkn, serviceAccountApprole);
 
@@ -3670,7 +3619,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(tkn);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeApproleFromIAMSvcAcc(userDetails, tkn, serviceAccountApprole);
 
@@ -3696,7 +3645,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(tkn);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeApproleFromIAMSvcAcc(userDetails, tkn, serviceAccountApprole);
 
@@ -3722,7 +3671,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(tkn);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeApproleFromIAMSvcAcc(userDetails, tkn, serviceAccountApprole);
 
@@ -3748,7 +3697,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(tkn);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeApproleFromIAMSvcAcc(userDetails, tkn, serviceAccountApprole);
 
@@ -3775,7 +3724,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(tkn);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeApproleFromIAMSvcAcc(userDetails, tkn, serviceAccountApprole);
 
@@ -5718,7 +5667,7 @@ public class IAMServiceAccountServiceTest {
 	        when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.addAwsRoleToIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
 	        assertEquals(HttpStatus.OK, responseEntityActual.getStatusCode());
@@ -5748,7 +5697,7 @@ public class IAMServiceAccountServiceTest {
 	        when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.addAwsRoleToIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
 	        assertEquals(HttpStatus.OK, responseEntityActual.getStatusCode());
@@ -5778,7 +5727,7 @@ public class IAMServiceAccountServiceTest {
 	        when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.addAwsRoleToIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
 	        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntityActual.getStatusCode());
@@ -5808,7 +5757,7 @@ public class IAMServiceAccountServiceTest {
 	        when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.addAwsRoleToIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
 	        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntityActual.getStatusCode());
@@ -5835,7 +5784,7 @@ public class IAMServiceAccountServiceTest {
 	        Response configureAWSRoleResponse = getMockResponse(HttpStatus.BAD_REQUEST, true, "");
 	        when(awsiamAuthService.configureAWSIAMRole(Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenReturn(configureAWSRoleResponse);
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.addAwsRoleToIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
 	        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntityActual.getStatusCode());
@@ -5852,7 +5801,7 @@ public class IAMServiceAccountServiceTest {
 	        IAMServiceAccountAWSRole serviceAccountAWSRole = new IAMServiceAccountAWSRole("testsvcname", "role1", "read", "1234568990");
 
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.addAwsRoleToIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
 	        assertEquals(HttpStatus.BAD_REQUEST, responseEntityActual.getStatusCode());
@@ -5881,7 +5830,7 @@ public class IAMServiceAccountServiceTest {
 	        Response updateMetadataResponse = getMockResponse(HttpStatus.NO_CONTENT, true, "");
 	        when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeAWSRoleFromIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
@@ -5911,7 +5860,7 @@ public class IAMServiceAccountServiceTest {
 	        Response updateMetadataResponse = getMockResponse(HttpStatus.NO_CONTENT, true, "");
 	        when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeAWSRoleFromIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
@@ -5942,7 +5891,7 @@ public class IAMServiceAccountServiceTest {
 	        when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeAWSRoleFromIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
@@ -5969,7 +5918,7 @@ public class IAMServiceAccountServiceTest {
 	        Response configureAWSRoleResponse = getMockResponse(HttpStatus.BAD_REQUEST, true, "");
 	        when(awsAuthService.configureAWSRole(Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenReturn(configureAWSRoleResponse);
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeAWSRoleFromIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
@@ -5986,7 +5935,7 @@ public class IAMServiceAccountServiceTest {
 	        IAMServiceAccountAWSRole serviceAccountAWSRole = new IAMServiceAccountAWSRole("testsvcname", "role1", "read", "1234568990");
 		   
 	        when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+	        when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 	        ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeAWSRoleFromIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
@@ -7038,6 +6987,69 @@ public class IAMServiceAccountServiceTest {
 	}
 
 	@Test
+	public void test_getListOfIAMServiceAccountAccessKeys_read_identity_policy_successfully() throws IOException {
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String iamSvcaccName = "testiamsvcacc01";
+		String awsAccountId = "1234567890";
+
+		// Mock approle permission check
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"default\"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
+		List<String> currentPolicies = new ArrayList<>();
+		currentPolicies.add("default");
+		List<String> identityPolicies = new ArrayList<>();
+		identityPolicies.add("r_iamsvcacc_1234567890_testiamsvcacc01");
+
+		when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
+		when(iamServiceAccountUtils.getIdentityPoliciesAsListFromTokenLookupJson(Mockito.any(), Mockito.any())).thenReturn(identityPolicies);
+
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId);
+		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void test_getListOfIAMServiceAccountAccessKeys_write_identity_policy_successfully() throws IOException {
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String iamSvcaccName = "testiamsvcacc01";
+		String awsAccountId = "1234567890";
+
+		// Mock approle permission check
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"default\"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
+		List<String> currentPolicies = new ArrayList<>();
+		currentPolicies.add("default");
+		List<String> identityPolicies = new ArrayList<>();
+		identityPolicies.add("w_iamsvcacc_1234567890_testiamsvcacc01");
+
+		when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
+		when(iamServiceAccountUtils.getIdentityPoliciesAsListFromTokenLookupJson(Mockito.any(), Mockito.any())).thenReturn(identityPolicies);
+
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId);
+		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void test_getListOfIAMServiceAccountAccessKeys_io_exception_failure() throws IOException {
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String iamSvcaccName = "testiamsvcacc01";
+		String awsAccountId = "1234567890";
+
+		// Mock approle permission check
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
+		List<String> currentPolicies = new ArrayList<>();
+		currentPolicies.add("iamportal_admin_policy");
+
+		when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenThrow(new IOException());
+
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId);
+		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
+	}
+
+	@Test
 	public void test_getListOfIAMServiceAccountAccessKeys_notauthorized_failed() {
 		String token = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
@@ -7652,7 +7664,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.associateApproletoIAMsvcacc(userDetails, token, serviceAccountApprole);
 
 		assertEquals(HttpStatus.BAD_REQUEST, responseEntityActual.getStatusCode());
@@ -7678,7 +7690,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.associateApproletoIAMsvcacc(userDetails, token, serviceAccountApprole);
 
 		assertEquals(HttpStatus.OK, responseEntityActual.getStatusCode());
@@ -7703,7 +7715,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.associateApproletoIAMsvcacc(userDetails, token, serviceAccountApprole);
 
 		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntityActual.getStatusCode());
@@ -7728,7 +7740,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeApproleFromIAMSvcAcc(userDetails, token, serviceAccountApprole);
 
@@ -7755,7 +7767,7 @@ public class IAMServiceAccountServiceTest {
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 
 		when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.addAwsRoleToIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 
 		assertEquals(HttpStatus.BAD_REQUEST, responseEntityActual.getStatusCode());
@@ -7780,7 +7792,7 @@ public class IAMServiceAccountServiceTest {
 		Response updateMetadataResponse = getMockResponse(HttpStatus.NO_CONTENT, true, "");
 		when(ControllerUtil.updateMetadata(Mockito.anyMap(),Mockito.anyString())).thenReturn(updateMetadataResponse);
 		when(tokenUtils.getSelfServiceToken()).thenReturn(token);
-		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"smohan11\",\"name\":\"svc_vault_test5\",\"users\":{\"smohan11\":\"sudo\"}}}"));
+		when(reqProcessor.process(eq("/sdb"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"initialPasswordReset\":true,\"managedBy\":\"auser\",\"name\":\"svc_vault_test5\",\"users\":{\"auser\":\"sudo\"}}}"));
 
 		ResponseEntity<String> responseEntityActual =  iamServiceAccountsService.removeAWSRoleFromIAMSvcacc(userDetails, token, serviceAccountAWSRole);
 

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/utils/IAMServiceAccountUtilsTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/utils/IAMServiceAccountUtilsTest.java
@@ -26,6 +26,7 @@ import com.tmobile.cso.vault.api.process.Response;
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.LogManager;
@@ -60,12 +61,11 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
 @ComponentScan(basePackages={"com.tmobile.cso.vault.api"})
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-@PrepareForTest({ JSONUtil.class, ControllerUtil.class, IAMServiceAccountUtils.class })
+@PrepareForTest({ JSONUtil.class, ControllerUtil.class })
 @PowerMockIgnore({"javax.management.*"})
 public class IAMServiceAccountUtilsTest {
 
@@ -177,28 +177,6 @@ public class IAMServiceAccountUtilsTest {
     }
 
     @Test
-    public void test_getIAMApproleToken_unsupported_encoding_exception() throws Exception {
-        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
-        when(ControllerUtil.getSscred()).thenReturn(new SSCred());
-        when(ControllerUtil.getIamUsername()).thenReturn("M2UyNTA0MGYtODIwNS02ZWM2LTI4Y2ItOGYwZTQ1NDI1YjQ4");
-        when(ControllerUtil.getIamPassword()).thenReturn("MWFjOGM1ZTgtZjE5Ny0yMTVlLTNmODUtZWIwMDc3ZmY3NmQw");
-
-        when(httpUtils.getHttpClient()).thenReturn(httpClient);
-        when(httpClient.execute(any())).thenReturn(httpResponse);
-        when(httpResponse.getStatusLine()).thenReturn(statusLine);
-        when(statusLine.getStatusCode()).thenReturn(200);
-        when(httpResponse.getEntity()).thenReturn(mockHttpEntity);
-
-        String responseString = "{\"auth\": {\"client_token\": \""+ tkn +"\"}}";
-        when(mockHttpEntity.getContent()).thenReturn( new ByteArrayInputStream(responseString.getBytes()));
-
-        whenNew(StringEntity.class).withArguments(Matchers.anyString()).thenThrow(new UnsupportedEncodingException());
-
-        String actualToken = iamServiceAccountUtils.getIAMApproleToken();
-        assertNull(actualToken);
-    }
-
-    @Test
     public void test_getIAMApproleToken_execute_failed() throws IOException {
         String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
         when(ControllerUtil.getSscred()).thenReturn(new SSCred());
@@ -253,47 +231,6 @@ public class IAMServiceAccountUtilsTest {
         IAMServiceAccountRotateRequest iamServiceAccountRotateRequest = new IAMServiceAccountRotateRequest(accessKeyId, iamServiceAccountName, awsAccountId);
         IAMServiceAccountSecret iamServiceAccountSecret = iamServiceAccountUtils.rotateIAMSecret(iamServiceAccountRotateRequest);
         assertEquals(expectedIamServiceAccountSecret.getAccessKeySecret(), iamServiceAccountSecret.getAccessKeySecret());
-    }
-
-    @Test
-    public void test_rotateIAMSecret_unsupported_encoding_exception_failed() throws Exception {
-        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
-        String iamServiceAccountName = "svc_vault_test5";
-        String awsAccountId = "1234567890";
-        String accessKeyId = "testaccesskey";
-        String iamSecret = "abcdefgh";
-        when(ControllerUtil.getSscred()).thenReturn(new SSCred());
-        when(ControllerUtil.getIamUsername()).thenReturn("M2UyNTA0MGYtODIwNS02ZWM2LTI4Y2ItOGYwZTQ1NDI1YjQ4");
-        when(ControllerUtil.getIamPassword()).thenReturn("MWFjOGM1ZTgtZjE5Ny0yMTVlLTNmODUtZWIwMDc3ZmY3NmQw");
-
-        when(httpUtils.getHttpClient()).thenReturn(httpClient);
-        when(httpClient.execute(any())).thenReturn(httpResponse);
-        when(httpResponse.getStatusLine()).thenReturn(statusLine);
-        when(statusLine.getStatusCode()).thenReturn(200);
-        when(httpResponse.getEntity()).thenReturn(mockHttpEntity);
-
-        String responseString = "{\"accessKeyId\": \"testaccesskey\", \"userName\": \"svc_vault_test5\", " +
-                "\"accessKeySecret\": \"abcdefgh\", \"expiryDateEpoch\": \"1609754282000\"}";
-        String responseStringToken = "{\"auth\": {\"client_token\": \""+ tkn +"\"}}";
-        when(mockHttpEntity.getContent()).thenAnswer(new Answer() {
-            private int count = 0;
-
-            public Object answer(InvocationOnMock invocation) {
-                if (count++ == 1)
-                    return new ByteArrayInputStream(responseString.getBytes());
-
-                return new ByteArrayInputStream(responseStringToken.getBytes());
-            }
-        });
-
-        when(JSONUtil.getJSON(any())).thenReturn("first").thenReturn("second");
-
-        whenNew(StringEntity.class).withArguments("second")
-                .thenThrow(new UnsupportedEncodingException());
-
-        IAMServiceAccountRotateRequest iamServiceAccountRotateRequest = new IAMServiceAccountRotateRequest(accessKeyId, iamServiceAccountName, awsAccountId);
-        IAMServiceAccountSecret iamServiceAccountSecret = iamServiceAccountUtils.rotateIAMSecret(iamServiceAccountRotateRequest);
-        assertNull(iamServiceAccountSecret);
     }
 
     @Test
@@ -888,82 +825,6 @@ public class IAMServiceAccountUtilsTest {
     }
 
     @Test
-    public void test_createAccessKeys_unsupported_encoding_exception_failed() throws Exception {
-        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
-        String iamServiceAccountName = "svc_vault_test5";
-        String awsAccountId = "1234567890";
-        String accessKeyId = "testaccesskey";
-        String iamSecret = "abcdefgh";
-        when(ControllerUtil.getSscred()).thenReturn(new SSCred());
-        when(ControllerUtil.getIamUsername()).thenReturn("M2UyNTA0MGYtODIwNS02ZWM2LTI4Y2ItOGYwZTQ1NDI1YjQ4");
-        when(ControllerUtil.getIamPassword()).thenReturn("MWFjOGM1ZTgtZjE5Ny0yMTVlLTNmODUtZWIwMDc3ZmY3NmQw");
-
-        when(httpUtils.getHttpClient()).thenReturn(httpClient);
-        when(httpClient.execute(any())).thenReturn(httpResponse);
-        when(httpResponse.getStatusLine()).thenReturn(statusLine);
-        when(statusLine.getStatusCode()).thenReturn(200);
-        when(httpResponse.getEntity()).thenReturn(mockHttpEntity);
-
-        String responseString = "{\"accessKeyId\": \"AKIA2GBSJB3123\",\"accessKeySecret\": \"abcdefgh\",\"awsAccountId\": \"1234567890\",\"createDate\": \"2021-05-03T08:56:42.000+0000\",\"expiryDate\": null,\"expiryDateEpoch\": 1627808202000,\"status\": \"Active\",\"userName\": \"svc_vault_test5\"}";
-        String responseStringToken = "{\"auth\": {\"client_token\": \""+ tkn +"\"}}";
-        when(mockHttpEntity.getContent()).thenAnswer(new Answer() {
-            private int count = 0;
-
-            public Object answer(InvocationOnMock invocation) {
-                if (count++ == 1)
-                    return new ByteArrayInputStream(responseString.getBytes());
-
-                return new ByteArrayInputStream(responseStringToken.getBytes());
-            }
-        });
-
-        whenNew(StringEntity.class).withArguments("{\"userName\": \"svc_vault_test5\",\"accountId\": \"1234567890\"}")
-                .thenThrow(new UnsupportedEncodingException());
-
-        IAMServiceAccountSecretResponse iamServiceAccountSecretResponse = iamServiceAccountUtils.createAccessKeys(awsAccountId, iamServiceAccountName);
-        assertNull(iamServiceAccountSecretResponse.getIamServiceAccountSecret());
-    }
-
-    @Test
-    public void test_createAccessKeys_general_exception_failed() throws Exception {
-        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
-        String iamServiceAccountName = "svc_vault_test5";
-        String awsAccountId = "1234567890";
-        String accessKeyId = "testaccesskey";
-        String iamSecret = "abcdefgh";
-        when(ControllerUtil.getSscred()).thenReturn(new SSCred());
-        when(ControllerUtil.getIamUsername()).thenReturn("M2UyNTA0MGYtODIwNS02ZWM2LTI4Y2ItOGYwZTQ1NDI1YjQ4");
-        when(ControllerUtil.getIamPassword()).thenReturn("MWFjOGM1ZTgtZjE5Ny0yMTVlLTNmODUtZWIwMDc3ZmY3NmQw");
-
-        when(httpUtils.getHttpClient()).thenReturn(httpClient);
-        when(httpClient.execute(any())).thenReturn(httpResponse);
-        when(httpResponse.getStatusLine()).thenReturn(statusLine);
-        when(statusLine.getStatusCode()).thenReturn(200);
-        when(httpResponse.getEntity()).thenReturn(mockHttpEntity);
-
-        String responseString = "{\"accessKeyId\": \"AKIA2GBSJB3123\",\"accessKeySecret\": \"abcdefgh\",\"awsAccountId\": \"1234567890\",\"createDate\": \"2021-05-03T08:56:42.000+0000\",\"expiryDate\": null,\"expiryDateEpoch\": 1627808202000,\"status\": \"Active\",\"userName\": \"svc_vault_test5\"}";
-        String responseStringToken = "{\"auth\": {\"client_token\": \""+ tkn +"\"}}";
-        when(mockHttpEntity.getContent()).thenAnswer(new Answer() {
-            private int count = 0;
-
-            public Object answer(InvocationOnMock invocation) {
-                if (count++ == 1)
-                    return new ByteArrayInputStream(responseString.getBytes());
-
-                return new ByteArrayInputStream(responseStringToken.getBytes());
-            }
-        });
-
-        whenNew(IAMServiceAccountSecret.class).withNoArguments()
-                .thenThrow(new IOException());
-
-        IAMServiceAccountSecret expectedIamServiceAccountSecret = new IAMServiceAccountSecret(iamServiceAccountName, accessKeyId, iamSecret, 1609754282000L, awsAccountId, "", "");
-
-        IAMServiceAccountSecretResponse iamServiceAccountSecretResponse = iamServiceAccountUtils.createAccessKeys(awsAccountId, iamServiceAccountName);
-        assertNull(iamServiceAccountSecretResponse.getIamServiceAccountSecret());
-    }
-
-    @Test
     public void test_createAccessKeys_null_http_client_success() throws IOException {
         String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
         String iamServiceAccountName = "svc_vault_test5";
@@ -1173,35 +1034,6 @@ public class IAMServiceAccountUtilsTest {
         when(mockHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(responseString.getBytes()));
 
         ReflectionTestUtils.setField(iamServiceAccountUtils, "iamPortalDeleteKeyEndpoint", "testendpoint");
-
-        boolean actualResult = iamServiceAccountUtils.deleteIAMAccesskeyFromIAM(awsAccountId, iamServiceAccountName, accessKeyId);
-        assertFalse(actualResult);
-    }
-
-    @Test
-    public void test_deleteIAMAccesskeyFromIAM_unsupported_encoding_exception_failed() throws Exception {
-        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
-        String iamServiceAccountName = "svc_vault_test5";
-        String awsAccountId = "1234567890";
-        String accessKeyId = "testaccesskey";
-
-        when(ControllerUtil.getSscred()).thenReturn(new SSCred());
-        when(ControllerUtil.getIamUsername()).thenReturn("M2UyNTA0MGYtODIwNS02ZWM2LTI4Y2ItOGYwZTQ1NDI1YjQ4");
-        when(ControllerUtil.getIamPassword()).thenReturn("MWFjOGM1ZTgtZjE5Ny0yMTVlLTNmODUtZWIwMDc3ZmY3NmQw");
-
-        when(httpUtils.getHttpClient()).thenReturn(httpClient);
-        when(httpClient.execute(any())).thenReturn(httpResponse);
-        when(httpResponse.getStatusLine()).thenReturn(statusLine);
-        when(statusLine.getStatusCode()).thenReturn(200);
-        when(httpResponse.getEntity()).thenReturn(mockHttpEntity);
-
-        String responseString = "{\"auth\": {\"client_token\": \"" + tkn + "\"}}";
-        when(mockHttpEntity.getContent()).thenReturn( new ByteArrayInputStream(responseString.getBytes()));
-
-        ReflectionTestUtils.setField(iamServiceAccountUtils, "iamPortalDeleteKeyEndpoint", "testendpoint");
-
-        String inputJson = "{\"accessKeyId\": \"testaccesskey\",\"accountId\": \"1234567890\",\"userName\": \"svc_vault_test5\"}";
-        whenNew(StringEntity.class).withArguments(inputJson).thenThrow(new UnsupportedEncodingException());
 
         boolean actualResult = iamServiceAccountUtils.deleteIAMAccesskeyFromIAM(awsAccountId, iamServiceAccountName, accessKeyId);
         assertFalse(actualResult);

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/utils/IAMServiceAccountUtilsTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/utils/IAMServiceAccountUtilsTest.java
@@ -1040,6 +1040,41 @@ public class IAMServiceAccountUtilsTest {
     }
 
     @Test
+    public void test_deleteIAMAccesskeyFromIAM_unsupported_encoding_exception_failed() throws Exception {
+        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+        String iamServiceAccountName = "svc_vault_test5";
+        String awsAccountId = "1234567890";
+        String accessKeyId = "testaccesskey";
+        String iamSecret = "omg_so_secret";
+        when(ControllerUtil.getSscred()).thenReturn(new SSCred());
+        when(ControllerUtil.getIamUsername()).thenReturn("M2UyNTA0MGYtODIwNS02ZWM2LTI4Y2ItOGYwZTQ1NDI1YjQ4");
+        when(ControllerUtil.getIamPassword()).thenReturn("MWFjOGM1ZTgtZjE5Ny0yMTVlLTNmODUtZWIwMDc3ZmY3NmQw");
+
+        when(httpUtils.getHttpClient()).thenReturn(httpClient);
+        when(httpClient.execute(any())).thenReturn(httpResponse);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(200);
+        when(httpResponse.getEntity()).thenReturn(mockHttpEntity);
+        String responseString = "{\"accessKeyId\": \"testaccesskey\", \"userName\": \"svc_vault_test5\", \"accessKeySecret\": \"abcdefgh\", \"expiryDateEpoch\": \"1609754282000\"}";
+        String responseStringToken = "{\"auth\": {\"client_token\": \""+tkn+"\"}}";
+        when(mockHttpEntity.getContent()).thenAnswer(new Answer() {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation) {
+                if (count++ == 1)
+                    return new ByteArrayInputStream(responseString.getBytes());
+
+                return new ByteArrayInputStream(responseStringToken.getBytes());
+            }
+        });
+
+        IAMServiceAccountSecret expectedIamServiceAccountSecret = new IAMServiceAccountSecret(iamServiceAccountName, accessKeyId, iamSecret, 1609754282000L, awsAccountId, "", "");
+        IAMServiceAccountRotateRequest iamServiceAccountRotateRequest = new IAMServiceAccountRotateRequest(accessKeyId, iamServiceAccountName, awsAccountId);
+        Boolean iamServiceAccountSecret = iamServiceAccountUtils.deleteIAMAccesskeyFromIAM(awsAccountId,iamServiceAccountName,accessKeyId);
+        assertEquals(false,iamServiceAccountSecret);
+    }
+
+    @Test
     public void test_deleteIAMAccesskeyFromIAM_null_http_client_failed() throws IOException {
         String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
         String iamServiceAccountName = "svc_vault_test5";


### PR DESCRIPTION
Updating API to get list of accesskeys for a given IAM Service Account for a user. Also removing newly added unit tests relying on PowerMockito because of an apparent conflict between PowerMockito and Jacoco in certain instances. Additionally, I have removed usages of real usernames from unit tests where found.