### PR TITLE
AppRole Transfer API

### DIFF
--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/controller/OIDCUtil.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/controller/OIDCUtil.java
@@ -650,7 +650,7 @@ public class OIDCUtil {
      * @param token
      * @return
      */
-    public void renewUserToken(String token) {
+    public Response renewUserToken(String token) {
         Response renewResponse = reqProcessor.process("/auth/tvault/renew", "{}", token);
         if (renewResponse != null && HttpStatus.OK.equals(renewResponse.getHttpstatus())) {
             log.info(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
@@ -660,6 +660,7 @@ public class OIDCUtil {
                     put(LogMessage.STATUS, renewResponse.getHttpstatus().toString()).
                     put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
                     build()));
+            return renewResponse;
         } else {
             log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
                     put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
@@ -669,8 +670,8 @@ public class OIDCUtil {
                     put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
                     build()));
         }
+        return null;
     }
-
 
     /**
      * Get Entity LookUp Response

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/AppRoleUpdate.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/AppRoleUpdate.java
@@ -18,7 +18,7 @@ public class AppRoleUpdate implements Serializable {
     private String owner;
 
     @Email
-    private String newOwnerEmail;
+    private String new_owner_email;
 
     private String role_name;
 
@@ -240,11 +240,11 @@ public class AppRoleUpdate implements Serializable {
         this.owner = owner;
     }
 
-    public String getNewOwnerEmail() {
-        return newOwnerEmail;
+    public String getNew_owner_email() {
+        return new_owner_email;
     }
 
-    public void setNewOwnerEmail(String newOwnerEmail) {
-        this.newOwnerEmail = newOwnerEmail;
+    public void setNew_owner_email(String new_owner_email) {
+        this.new_owner_email = new_owner_email;
     }
 }

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/AppRoleUpdate.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/AppRoleUpdate.java
@@ -1,0 +1,250 @@
+package com.tmobile.cso.vault.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.validator.constraints.Email;
+import org.hibernate.validator.constraints.NotBlank;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+import java.io.Serializable;
+import java.util.List;
+
+public class AppRoleUpdate implements Serializable {
+    private static final long serialVersionUID = 4510268414369277124L;
+
+    @Pattern(regexp = "^$|^[a-zA-Z0-9_-]+$", message = "Owner can have alphabets, numbers, _ and - characters only")
+    private String owner;
+
+    @Email
+    private String newOwnerEmail;
+
+    private String role_name;
+
+    private String[] policies;
+
+    private boolean bind_secret_id;
+
+    @Min(0)
+    @Max(999999999)
+    private Integer secret_id_num_uses;
+
+    @Min(0)
+    @Max(999999999)
+    private Integer secret_id_ttl;
+
+    @Min(0)
+    @Max(999999999)
+    private Integer token_num_uses;
+
+    @Min(0)
+    @Max(999999999)
+    private Integer token_ttl;
+
+    @Min(0)
+    @Max(999999999)
+    private Integer token_max_ttl;
+
+    private List<String> shared_to;
+
+    public AppRoleUpdate() {
+    }
+
+    public AppRoleUpdate(String role_name, String[] policies, boolean bind_secret_id, Integer secret_id_num_uses,
+                   Integer secret_id_ttl, Integer token_num_uses) {
+        super();
+        this.role_name = role_name;
+        this.policies = policies;
+        this.bind_secret_id = bind_secret_id;
+        this.secret_id_num_uses = secret_id_num_uses;
+        this.secret_id_ttl = secret_id_ttl;
+        this.token_num_uses = token_num_uses;
+    }
+
+    public AppRoleUpdate(String role_name, String[] policies, boolean bind_secret_id, Integer secret_id_num_uses,
+                   Integer secret_id_ttl, Integer token_num_uses, Integer token_ttl, Integer token_max_ttl) {
+        super();
+        this.role_name = role_name;
+        this.policies = policies;
+        this.bind_secret_id = bind_secret_id;
+        this.secret_id_num_uses = secret_id_num_uses;
+        this.secret_id_ttl = secret_id_ttl;
+        this.token_num_uses = token_num_uses;
+        this.token_ttl = token_ttl;
+        this.token_max_ttl = token_max_ttl;
+    }
+
+    public AppRoleUpdate(String role_name, String[] policies, boolean bind_secret_id, Integer secret_id_num_uses,
+                   Integer secret_id_ttl, Integer token_num_uses, Integer token_ttl, Integer token_max_ttl, List<String> sharedTo) {
+        super();
+        this.role_name = role_name;
+        this.policies = policies;
+        this.bind_secret_id = bind_secret_id;
+        this.secret_id_num_uses = secret_id_num_uses;
+        this.secret_id_ttl = secret_id_ttl;
+        this.token_num_uses = token_num_uses;
+        this.token_ttl = token_ttl;
+        this.token_max_ttl = token_max_ttl;
+        this.shared_to = sharedTo;
+    }
+
+    public AppRoleUpdate(String owner, String role_name, String[] policies, boolean bind_secret_id, Integer secret_id_num_uses,
+                   Integer secret_id_ttl, Integer token_num_uses, Integer token_ttl, Integer token_max_ttl, List<String> shared_to) {
+        this.owner = owner;
+        this.role_name = role_name;
+        this.policies = policies;
+        this.bind_secret_id = bind_secret_id;
+        this.secret_id_num_uses = secret_id_num_uses;
+        this.secret_id_ttl = secret_id_ttl;
+        this.token_num_uses = token_num_uses;
+        this.token_ttl = token_ttl;
+        this.token_max_ttl = token_max_ttl;
+        this.shared_to = shared_to;
+    }
+
+    /**
+     * @return the role_name
+     */
+    @ApiModelProperty(example="myvaultapprole", position=1)
+    public String getRole_name() {
+        return role_name;
+    }
+
+    /**
+     * @param role_name the role_name to set
+     */
+    @ApiModelProperty(example="ccp-approle", position=2, required=true)
+    public void setRole_name(String role_name) {
+        this.role_name = role_name;
+    }
+
+    /**
+     * @return the policies
+     */
+    @ApiModelProperty(hidden=true, position=3)
+    public String[] getPolicies() {
+        return policies;
+    }
+
+    /**
+     * @param policies the policies to set
+     */
+    public void setPolicies(String[] policies) {
+        this.policies = policies;
+    }
+
+    /**
+     * @return the bind_secret_id
+     */
+    @ApiModelProperty(hidden=true, example="true", position=4)
+    public boolean isBind_secret_id() {
+        return bind_secret_id;
+    }
+
+    /**
+     * @param bind_secret_id the bind_secret_id to set
+     */
+    public void setBind_secret_id(boolean bind_secret_id) {
+        this.bind_secret_id = bind_secret_id;
+    }
+
+    /**
+     * @return the secret_id_num_uses
+     */
+    @ApiModelProperty(example="1", position=5)
+    public Integer getSecret_id_num_uses() {
+        return secret_id_num_uses;
+    }
+
+    /**
+     * @param secret_id_num_uses the secret_id_num_uses to set
+     */
+    public void setSecret_id_num_uses(Integer secret_id_num_uses) {
+        this.secret_id_num_uses = secret_id_num_uses;
+    }
+
+    /**
+     * @return the secret_id_ttl
+     */
+    @ApiModelProperty(example="900", position=6)
+    public Integer getSecret_id_ttl() {
+        return secret_id_ttl;
+    }
+
+    /**
+     * @param secret_id_ttl the secret_id_ttl to set
+     */
+    public void setSecret_id_ttl(Integer secret_id_ttl) {
+        this.secret_id_ttl = secret_id_ttl;
+    }
+
+    /**
+     * @return the token_num_uses
+     */
+    @ApiModelProperty(example="1", position=7)
+    public Integer getToken_num_uses() {
+        return token_num_uses;
+    }
+
+    /**
+     * @param token_num_uses the token_num_uses to set
+     */
+    public void setToken_num_uses(Integer token_num_uses) {
+        this.token_num_uses = token_num_uses;
+    }
+
+    /**
+     * @return the token_ttl
+     */
+    @ApiModelProperty(example="60", position=8)
+    public Integer getToken_ttl() {
+        return token_ttl;
+    }
+
+    /**
+     * @return the token_max_ttl
+     */
+    @ApiModelProperty(example="900", position=9)
+    public Integer getToken_max_ttl() {
+        return token_max_ttl;
+    }
+
+    /**
+     * @param token_ttl the token_ttl to set
+     */
+    public void setToken_ttl(Integer token_ttl) {
+        this.token_ttl = token_ttl;
+    }
+
+    /**
+     * @param token_max_ttl the token_max_ttl to set
+     */
+    public void setToken_max_ttl(Integer token_max_ttl) {
+        this.token_max_ttl = token_max_ttl;
+    }
+
+    public List<String> getShared_to() {
+        return shared_to;
+    }
+
+    public void setShared_to(List<String> shared_to) {
+        this.shared_to = shared_to;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public String getNewOwnerEmail() {
+        return newOwnerEmail;
+    }
+
+    public void setNewOwnerEmail(String newOwnerEmail) {
+        this.newOwnerEmail = newOwnerEmail;
+    }
+}

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/AppRoleService.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/AppRoleService.java
@@ -1756,13 +1756,13 @@ public class  AppRoleService {
 						put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 						build()));
 				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(String.format(
-						"{\"errors\":[\"An AppRole cannot be shared with its owner. Please remove owner %s from the shared_to field, " +
+						"{\"errors\":[\"An AppRole cannot be shared with its owner. Please remove owner %s as a shared user, " +
 								"or change the owner.\"]}", appRoleUpdate.getOwner()));
 			}
 			isOwnershipChanged = !appRoleUpdate.getOwner().isEmpty();
 		}
 
-		if (!validateNoSharedUserIsOwner(appRoleMetadataDetails, appRole.getShared_to())) {
+		if (!isOwnershipChanged && !validateNoSharedUserIsOwner(appRoleMetadataDetails, appRole.getShared_to())) {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 					.body("{\"errors\":[\"An AppRole cannot be shared with the current owner\"]}");
 		}
@@ -1823,9 +1823,9 @@ public class  AppRoleService {
 								put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 								build()));
 
-						if (appRoleUpdate.getNewOwnerEmail() != null) {
+						if (appRoleUpdate.getNew_owner_email() != null) {
 							sendNotificationEmail(appRoleMetadataDetails.getCreatedBy(), appRole.getRole_name(),
-									appRoleUpdate.getNewOwnerEmail());
+									appRoleUpdate.getNew_owner_email());
 						}
 					} else {
 						log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/AppRoleService.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/AppRoleService.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.util.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.tmobile.cso.vault.api.model.*;
+import com.tmobile.cso.vault.api.utils.CommonUtils;
+import com.tmobile.cso.vault.api.utils.EmailUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -40,17 +43,6 @@ import com.tmobile.cso.vault.api.common.SSLCertificateConstants;
 import com.tmobile.cso.vault.api.common.TVaultConstants;
 import com.tmobile.cso.vault.api.controller.ControllerUtil;
 import com.tmobile.cso.vault.api.exception.LogMessage;
-import com.tmobile.cso.vault.api.model.AppRole;
-import com.tmobile.cso.vault.api.model.AppRoleAccessorId;
-import com.tmobile.cso.vault.api.model.AppRoleAccessorIds;
-import com.tmobile.cso.vault.api.model.AppRoleDetails;
-import com.tmobile.cso.vault.api.model.AppRoleIdSecretId;
-import com.tmobile.cso.vault.api.model.AppRoleMetadata;
-import com.tmobile.cso.vault.api.model.AppRoleMetadataDetails;
-import com.tmobile.cso.vault.api.model.AppRoleNameSecretId;
-import com.tmobile.cso.vault.api.model.AppRoleSecretData;
-import com.tmobile.cso.vault.api.model.SafeAppRoleAccess;
-import com.tmobile.cso.vault.api.model.UserDetails;
 import com.tmobile.cso.vault.api.process.RequestProcessor;
 import com.tmobile.cso.vault.api.process.Response;
 import com.tmobile.cso.vault.api.utils.JSONUtil;
@@ -67,6 +59,15 @@ public class  AppRoleService {
 
 	@Value("${vault.auth.method}")
 	private String vaultAuthMethod;
+
+	@Value("${ad.notification.fromemail}")
+	private String supportEmail;
+
+	@Autowired
+	private EmailUtils emailUtils;
+
+	@Autowired
+	private CommonUtils commonUtils;
 
 	private static Logger log = LogManager.getLogger(AppRoleService.class);
 	
@@ -138,7 +139,7 @@ public class  AppRoleService {
 		if (!isDuplicate) {
 			Response response = reqProcessor.process(CREATEPATH, jsonStr,token);
 			if (response.getHttpstatus().equals(HttpStatus.NO_CONTENT) || response.getHttpstatus().equals(HttpStatus.OK)) {
-				boolean metadataCreatedSuccessfully = createAppRoleMetaData(token, userDetails, appRole);
+				boolean metadataCreatedSuccessfully = createAppRoleMetaData(token, appRole, userDetails.getUsername());
 				if(metadataCreatedSuccessfully) {
 					log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
 							put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
@@ -184,16 +185,16 @@ public class  AppRoleService {
 	 * @param appRole
 	 * @return boolean
 	 */
-	private boolean createAppRoleMetaData(String token, UserDetails userDetails, AppRole appRole) {
-		String metadataJson = ControllerUtil.populateAppRoleMetaJson(appRole, userDetails.getUsername());
+	private boolean createAppRoleMetaData(String token, AppRole appRole, String username) {
+		String metadataJson = ControllerUtil.populateAppRoleMetaJson(appRole, username);
 		boolean appRoleMetaDataCreationStatus = ControllerUtil.createMetadata(metadataJson, token);
-		String appRoleUsermetadataJson = ControllerUtil.populateUserMetaJson(appRole, userDetails.getUsername());
+		String appRoleUsermetadataJson = ControllerUtil.populateUserMetaJson(appRole, username);
 		boolean appRoleUserMetaDataCreationStatus = ControllerUtil.createMetadata(appRoleUsermetadataJson, token);
 		boolean appRoleSharedToUserMetaDataCreationStatus = true;
 		if (appRole.getShared_to() != null) {
 			for (String sharedToUser : appRole.getShared_to()) {
 				if (StringUtils.isNotEmpty(sharedToUser)) {
-					String appRoleSharedToMetadataJson = ControllerUtil.populateSharedToUserMetaJson(userDetails.getUsername(), sharedToUser, appRole);
+					String appRoleSharedToMetadataJson = ControllerUtil.populateSharedToUserMetaJson(username, sharedToUser, appRole);
 					appRoleSharedToUserMetaDataCreationStatus = ControllerUtil.createMetadata(appRoleSharedToMetadataJson, token);
 				}
 			}
@@ -1666,30 +1667,33 @@ public class  AppRoleService {
 		
 		}
 	}
+
 	/**
-	 * Updates an AppRole
+	 * Updates an AppRole, including ability to transfer ownership.
 	 * @param token
-	 * @param appRole
+	 * @param appRoleUpdate
 	 * @param userDetails
-	 * @return
+	 * @return ResponseEntity
 	 */
-	public ResponseEntity<String> updateAppRole(String token, AppRole appRole, UserDetails userDetails) {
+	public ResponseEntity<String> updateAppRole(String token, AppRoleUpdate appRoleUpdate, UserDetails userDetails) {
 		log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
 			      put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
 				  put(LogMessage.ACTION,UPDATE_APPROLE).
-			      put(LogMessage.MESSAGE, String.format("Start trying to update AppRole [%s]", appRole.getRole_name())).
+			      put(LogMessage.MESSAGE, String.format("Start trying to update AppRole [%s]", appRoleUpdate.getRole_name())).
 			      put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 			      build()));
-		if (StringUtils.isEmpty(appRole.getRole_name())) {
+		if (StringUtils.isEmpty(appRoleUpdate.getRole_name())) {
 			log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
 				      put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
 					  put(LogMessage.ACTION, UPDATE_APPROLE).
 				      put(LogMessage.MESSAGE, "Not enough information to update AppRole").
 				      put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 				      build()));
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("{\"errors\":[\"AppRole can't be updated since insufficient information has been provided.\"]}");		
-
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+					"{\"errors\":[\"AppRole can't be updated since insufficient information has been provided.\"]}");
 		}
+
+		AppRole appRole = constructAppRoleFromUpdateObject(appRoleUpdate);
 		String rolename = appRole.getRole_name();
 
 		if (Arrays.asList(TVaultConstants.SELF_SUPPORT_ADMIN_APPROLES).contains(rolename)) {
@@ -1708,6 +1712,56 @@ public class  AppRoleService {
 
 		AppRoleMetadataDetails appRoleMetadataDetails = readAppRoleMetadata(token, rolename).getAppRoleMetadataDetails();
 		boolean isSharedToChanged = isSharedToChanged(appRoleMetadataDetails, appRole.getShared_to());
+		boolean isOwnershipChanged = false;
+		if (appRoleUpdate.getOwner() != null) {
+			if (!userDetails.getUsername().equals(appRoleMetadataDetails.getCreatedBy()) && !userDetails.isAdmin()) {
+				log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
+						put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
+						put(LogMessage.ACTION, UPDATE_APPROLE).
+						put(LogMessage.MESSAGE, String.format("Unable to transfer owner on AppRole [%s] because user %s is not the owner or admin.",
+								rolename, appRoleUpdate.getOwner())).
+						put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
+						build()));
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(String.format(
+						"{\"errors\":[\"Unable to transfer ownership of AppRole %s because you are not the owner of the AppRole or an admin user.\"]}",
+						rolename, appRoleUpdate.getOwner()));
+			}
+			if (appRoleMetadataDetails.getCreatedBy().equals(appRoleUpdate.getOwner())) {
+				log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
+						put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
+						put(LogMessage.ACTION, UPDATE_APPROLE).
+						put(LogMessage.MESSAGE, String.format("Unable to transfer owner on AppRole [%s] because [%s] is already the owner",
+								rolename, appRoleUpdate.getOwner())).
+						put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
+						build()));
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(String.format(
+						"{\"errors\":[\"Unable to transfer ownership of AppRole %s because %s is already the owner\"]}",
+						rolename, appRoleUpdate.getOwner()));
+			}
+
+			boolean newOwnerIsSharedUser = false;
+			if (appRoleMetadataDetails.getSharedTo() != null &&
+					appRoleMetadataDetails.getSharedTo().contains(appRoleUpdate.getOwner())) {
+				newOwnerIsSharedUser = true;
+			}
+			if (appRoleUpdate.getShared_to() != null && appRoleUpdate.getShared_to().contains(appRoleUpdate.getOwner())) {
+				newOwnerIsSharedUser = true;
+			}
+			if (newOwnerIsSharedUser) {
+				log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
+						put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
+						put(LogMessage.ACTION, UPDATE_APPROLE).
+						put(LogMessage.MESSAGE, String.format("Unable to share AppRole [%s] with [%s] because they are the existing owner.",
+								rolename, appRoleUpdate.getOwner())).
+						put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
+						build()));
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(String.format(
+						"{\"errors\":[\"An AppRole cannot be shared with its owner. Please remove owner %s from the shared_to field, " +
+								"or change the owner.\"]}", appRoleUpdate.getOwner()));
+			}
+			isOwnershipChanged = !appRoleUpdate.getOwner().isEmpty();
+		}
+
 		if (!validateNoSharedUserIsOwner(appRoleMetadataDetails, appRole.getShared_to())) {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 					.body("{\"errors\":[\"An AppRole cannot be shared with the current owner\"]}");
@@ -1723,7 +1777,7 @@ public class  AppRoleService {
 					put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 					build()));
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
-					String.format("Unable to update shared_to on AppRole [%s] because you are not the owner", rolename));
+					String.format("{\"errors\":[\"Unable to update shared_to on AppRole %s because you are not the owner\"]}", rolename));
 		}
 
 		AppRole existingAppRole = readAppRoleBasicDetails(token, rolename);
@@ -1750,9 +1804,43 @@ public class  AppRoleService {
 				      put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 				      build()));
 
-			if (isSharedToChanged) {
-				createAppRoleMetaData(token, userDetails, appRole);
+			if (null == appRole.getShared_to()) {
+				appRole.setShared_to(appRoleMetadataDetails.getSharedTo());
+			}
 
+			if (isSharedToChanged || isOwnershipChanged) {
+				String username = userDetails.getUsername();
+				if (isOwnershipChanged) {
+					username = appRoleUpdate.getOwner();
+					String appRoleUsermetadataJson = ControllerUtil.populateUserMetaJson(appRole, appRoleMetadataDetails.getCreatedBy());
+					Response appRoleUserMetaDataDeletionResponse = reqProcessor.process("/delete", appRoleUsermetadataJson, token);
+					if (appRoleUserMetaDataDeletionResponse.getHttpstatus().equals(HttpStatus.NO_CONTENT)) {
+						log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
+								put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
+								put(LogMessage.ACTION, UPDATE_APPROLE).
+								put(LogMessage.MESSAGE, String.format("Successfully deleted metadata for old AppRole owner [%s]",
+										appRoleMetadataDetails.getCreatedBy())).
+								put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
+								build()));
+
+						if (appRoleUpdate.getNewOwnerEmail() != null) {
+							sendNotificationEmail(appRoleMetadataDetails.getCreatedBy(), appRole.getRole_name(),
+									appRoleUpdate.getNewOwnerEmail());
+						}
+					} else {
+						log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
+								put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
+								put(LogMessage.ACTION, UPDATE_APPROLE).
+								put(LogMessage.MESSAGE, String.format("Error deleting metadata for old AppRole owner [%s]",
+										appRoleMetadataDetails.getCreatedBy())).
+								put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
+								build()));
+					}
+				}
+				createAppRoleMetaData(token, appRole, username);
+			}
+
+			if (isSharedToChanged) {
 				List<String> usersToBeRemovedFromSharedList = appRoleMetadataDetails.getSharedTo();
 				if (!CollectionUtils.isEmpty(usersToBeRemovedFromSharedList)) {
 					if (appRole.getShared_to() != null) {
@@ -1760,24 +1848,26 @@ public class  AppRoleService {
 					}
 
 					for (String userToBeRemoved : usersToBeRemovedFromSharedList) {
-						String path = TVaultConstants.APPROLE_USERS_METADATA_MOUNT_PATH + "/" + userToBeRemoved + "/" + appRole.getRole_name();
-						Response deleteResponse = reqProcessor.process("/delete", "{\"path\":\"" + path + "\"}", token);
-						if (HttpStatus.NO_CONTENT.equals(deleteResponse.getHttpstatus())) {
-							log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
-									put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
-									put(LogMessage.ACTION, SSLCertificateConstants.DELETE_METADATA_PERMISSIONS).
-									put(LogMessage.MESSAGE, String.format("Successfully deleted metadata for user [%s]", userToBeRemoved)).
-									put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
-									build()));
-						} else {
-							log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
-									put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
-									put(LogMessage.ACTION, SSLCertificateConstants.DELETE_METADATA_PERMISSIONS).
-									put(LogMessage.MESSAGE, String.format("Failed to delete metadata for user [%s]", userToBeRemoved)).
-									put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
-									build()));
-							return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-									String.format("{\"errors\":[\"Failed to delete metadata for user %s\"]}", userToBeRemoved));
+						if (!userToBeRemoved.equals(appRoleUpdate.getOwner())) {
+							String path = TVaultConstants.APPROLE_USERS_METADATA_MOUNT_PATH + "/" + userToBeRemoved + "/" + appRole.getRole_name();
+							Response deleteResponse = reqProcessor.process("/delete", "{\"path\":\"" + path + "\"}", token);
+							if (HttpStatus.NO_CONTENT.equals(deleteResponse.getHttpstatus())) {
+								log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
+										put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
+										put(LogMessage.ACTION, SSLCertificateConstants.DELETE_METADATA_PERMISSIONS).
+										put(LogMessage.MESSAGE, String.format("Successfully deleted metadata for user [%s]", userToBeRemoved)).
+										put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
+										build()));
+							} else {
+								log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
+										put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
+										put(LogMessage.ACTION, SSLCertificateConstants.DELETE_METADATA_PERMISSIONS).
+										put(LogMessage.MESSAGE, String.format("Failed to delete metadata for user [%s]", userToBeRemoved)).
+										put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
+										build()));
+								return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+										String.format("{\"errors\":[\"Failed to delete metadata for user %s\"]}", userToBeRemoved));
+							}
 						}
 					}
 				}
@@ -1794,7 +1884,32 @@ public class  AppRoleService {
 			      put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 			      build()));
 		return ResponseEntity.status(response.getHttpstatus()).body(response.getResponse());
-	
+	}
+
+	private void sendNotificationEmail(String originalAppRoleOwner, String appRoleName, String ownerEmail) {
+		DirectoryUser oldOwnerObj = commonUtils.getUserDetails(originalAppRoleOwner);
+		Map<String, String> mailTemplateVariables = new HashMap<>();
+		mailTemplateVariables.put("appRoleName", appRoleName);
+		mailTemplateVariables.put("oldOwnerName", oldOwnerObj != null ? oldOwnerObj.getDisplayName() : "");
+		List<String> cc = new ArrayList<>();
+		List<String> to = new ArrayList<>();
+		to.add(ownerEmail);
+		String subject = String.format("AppRole %s has been successfully transferred", appRoleName);
+		emailUtils.sendAppRoleHtmlEmalFromTemplate(supportEmail, to, cc, subject, mailTemplateVariables, "AppRoleTransferEmailTemplate");
+	}
+
+	private AppRole constructAppRoleFromUpdateObject(AppRoleUpdate appRoleUpdate) {
+		AppRole appRole = new AppRole();
+		appRole.setRole_name(appRoleUpdate.getRole_name());
+		appRole.setPolicies(appRoleUpdate.getPolicies());
+		appRole.setBind_secret_id(appRoleUpdate.isBind_secret_id());
+		appRole.setSecret_id_num_uses(appRoleUpdate.getSecret_id_num_uses());
+		appRole.setToken_num_uses(appRoleUpdate.getToken_num_uses());
+		appRole.setToken_ttl(appRoleUpdate.getToken_ttl());
+		appRole.setToken_max_ttl(appRoleUpdate.getToken_max_ttl());
+		appRole.setShared_to(appRoleUpdate.getShared_to());
+
+		return appRole;
 	}
 
 	private boolean validateNoSharedUserIsOwner(AppRoleMetadataDetails appRoleMetadataDetails, List<String> sharedUsers) {
@@ -1836,7 +1951,10 @@ public class  AppRoleService {
 	}
 
 	/**
-	 * Determines whether user is the creator of the approle
+	 * Determines whether the sharedTo list has changed. <br>
+	 * If the sharedTo list is null then we assume the user doesn't want to make a change to the field, <br>
+	 * so false is returned in that scenario.
+	 *
 	 * @param appRoleMetadataDetails
 	 * @param newSharedTo
 	 * @return boolean
@@ -1849,6 +1967,9 @@ public class  AppRoleService {
 				put(LogMessage.MESSAGE, "Check to see if sharedTo array changed failed because appRoleMetadataDetails was null").
 				put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 				build()));
+			return false;
+		}
+		if (newSharedTo == null) {
 			return false;
 		}
 		List<String> oldSharedTo = appRoleMetadataDetails.getSharedTo();

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/IAMServiceAccountsService.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/IAMServiceAccountsService.java
@@ -24,6 +24,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import com.tmobile.cso.vault.api.utils.*;
+import com.unboundid.util.json.JSONObject;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.ArrayUtils;
@@ -462,12 +463,69 @@ public class  IAMServiceAccountsService {
 
 	/**
 	 * To check if the user/token has permission to read access keys for IAM service account.
+	 * @param userDetails
 	 * @param token
 	 * @param iamSvcAccName
 	 * @param awsAccountId
 	 * @return boolean
 	 */
-	private boolean isAuthorizedToReadAccessKeys(String token, String iamSvcAccName, String awsAccountId) {
+	private boolean isAuthorizedToReadAccessKeys(UserDetails userDetails, String token, String iamSvcAccName, String awsAccountId) throws IOException {
+		boolean isAuthorized = false;
+
+		String selfSupportToken = userDetails.getSelfSupportToken();
+
+		JsonObject iamMetadata = getIAMMetadata(selfSupportToken, awsAccountId + "_" + iamSvcAccName);
+		JsonElement appRoleElement = iamMetadata.get("app-roles");
+		JsonElement awsRoleElement = iamMetadata.get("aws-roles");
+		Map<String, Object> appRoles = null;
+		Map<String, Object> awsRoles = null;
+		if (appRoleElement != null) {
+			appRoles = ControllerUtil.parseJson(appRoleElement.toString());
+		}
+		if (awsRoleElement != null) {
+			awsRoles = ControllerUtil.parseJson(iamMetadata.get("aws-roles").toString());
+		}
+
+		if (appRoles != null) {
+			for (Map.Entry<String, Object> entry : appRoles.entrySet()) {
+				AppRoleMetadata appRoleMetadata = appRoleService.readAppRoleMetadata(selfSupportToken, entry.getKey());
+				if (appRoleMetadata != null) {
+					AppRoleMetadataDetails arDetails = appRoleMetadata.getAppRoleMetadataDetails();
+					if (arDetails.getCreatedBy().equals(userDetails.getUsername()) ||
+							(arDetails.getSharedTo() != null && arDetails.getSharedTo().contains(userDetails.getUsername()))) {
+						if (entry.getValue().equals(TVaultConstants.DENY_POLICY)) {
+							log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder()
+									.put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER))
+									.put(LogMessage.ACTION, "isAuthorizedToReadAccessKeys")
+									.put(LogMessage.MESSAGE, String.format("User %s is denied permission to read access keys because " +
+													"of approle %s", userDetails.getUsername(), entry.getKey()))
+									.put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).build()));
+							return false;
+						} else {
+							isAuthorized = true;
+						}
+					}
+				}
+			}
+		}
+
+		if (awsRoles != null) {
+			for (Map.Entry<String, Object> entry : awsRoles.entrySet()) {
+				String path = PATHSTR + "metadata/awsrole/" + entry.getKey() + "\"}";
+				Response awsMetaResponse = reqProcessor.process("/read", path, selfSupportToken);
+				if (awsMetaResponse.getHttpstatus().equals(HttpStatus.OK)) {
+					String createdBy = new ObjectMapper().readTree(awsMetaResponse.getResponse()).get("data").get("createdBy").textValue();
+					if (createdBy.equals(userDetails.getUsername())) {
+						if (entry.getValue().equals(TVaultConstants.DENY_POLICY)) {
+							return false;
+						} else {
+							isAuthorized = true;
+						}
+					}
+				}
+			}
+		}
+
 		Response response = reqProcessor.process("/auth/tvault/lookup","{}", token);
 		if(HttpStatus.OK.equals(response.getHttpstatus())) {
 			Response renewResponse = oidcUtil.renewUserToken(token);
@@ -481,33 +539,28 @@ public class  IAMServiceAccountsService {
 							put(LogMessage.MESSAGE, "Parsing Json for isAuthorizedToReadAccessKeys failed").
 							put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
 							build()));
-					return false;
-				}
+				} else {
+					String readPolicyName = "r_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
+					String writePolicyName = "w_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
+					String denyPolicyName = "d_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
+					@SuppressWarnings("unchecked")
+					List<String> policies = (List<String>) responseMap.get("policies");
 
-				@SuppressWarnings("unchecked")
-				List<String> policies = (List<String>) responseMap.get("policies");
-
-				String readPolicyName = "r_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
-				String writePolicyName = "w_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
-				String denyPolicyName = "d_iamsvcacc_" + awsAccountId + "_" + iamSvcAccName;
-
-				if (!policies.contains(denyPolicyName) && (policies.contains(iamSelfSupportAdminPolicyName) ||
-						policies.stream().anyMatch((policy) -> policy.startsWith(readPolicyName) || policy.startsWith(writePolicyName)))) {
-					log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder()
-							.put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER))
-							.put(LogMessage.ACTION, "isAuthorizedToReadAccessKeys")
-							.put(LogMessage.MESSAGE, "The User/Token has required policies to read access keys for IAM Service Account.")
-							.put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).build()));
-					return true;
+					if (policies.contains(denyPolicyName)) {
+						return false;
+					} else if (policies.contains(iamSelfSupportAdminPolicyName) || policies.stream()
+							.anyMatch((policy) -> policy.startsWith(readPolicyName) || policy.startsWith(writePolicyName))) {
+						log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder()
+								.put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER))
+								.put(LogMessage.ACTION, "isAuthorizedToReadAccessKeys")
+								.put(LogMessage.MESSAGE, "The User/Token has required policies to read access keys for IAM Service Account.")
+								.put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).build()));
+						isAuthorized = true;
+					}
 				}
 			}
 		}
-		log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder()
-				.put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER))
-				.put(LogMessage.ACTION, "isAuthorizedToReadAccessKeys")
-				.put(LogMessage.MESSAGE, "The User/Token does not have required policies to read access keys for IAM Service Account.")
-				.put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).build()));
-		return false;
+		return isAuthorized;
 	}
 
 	/**
@@ -5091,7 +5144,7 @@ public class  IAMServiceAccountsService {
 	 * @return ResponseEntity
 	 */
 	public ResponseEntity<String> getListOfIAMServiceAccountAccessKeys(String token, String iamSvcaccName,
-																	   String awsAccountId, UserDetails userDetails) {
+																	   String awsAccountId, UserDetails userDetails) throws IOException {
 		iamSvcaccName = iamSvcaccName.toLowerCase();
 		String uniqueIAMSvcName = awsAccountId + "_" + iamSvcaccName;
 		log.debug(JSONUtil.getJSON(ImmutableMap.<String, String>builder()
@@ -5100,7 +5153,7 @@ public class  IAMServiceAccountsService {
 				.put(LogMessage.MESSAGE, String.format("Trying to get the list of IAM Service Account [%s] access keys", iamSvcaccName))
 				.put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).build()));
 
-		if (!isAuthorizedToReadAccessKeys(token, iamSvcaccName, awsAccountId)) {
+		if (!isAuthorizedToReadAccessKeys(userDetails, token, iamSvcaccName, awsAccountId)) {
 			log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder()
 					.put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER))
 					.put(LogMessage.ACTION, IAMServiceAccountConstants.GET_IAMSVCACC_ACCESSKEY_LIST_MSG)

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/SSLCertificateService.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/SSLCertificateService.java
@@ -5246,6 +5246,9 @@ public ResponseEntity<String> getRevocationReasons(Integer certificateId, String
                 }
 
             }else {
+                if (String.valueOf(certificateId).equalsIgnoreCase(String.valueOf(certData.getCertificateId()))) {
+                    certData = getRenewedCertificate(certType, certificateName, nclmAccessToken, containerId, certificateId);
+                }
 				metaDataParams.put(SSLCertificateConstants.CERTIFICATE_ID,((Integer)certData.getCertificateId()).toString()!=null?
 						((Integer)certData.getCertificateId()).toString():String.valueOf(certificateId));
 				metaDataParams.put("createDate", certData.getCreateDate()!=null?certData.getCreateDate():object.get("createDate").getAsString());

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/SelfSupportService.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/SelfSupportService.java
@@ -1001,12 +1001,12 @@ public class  SelfSupportService {
 	/**
 	 * Update AppRole
 	 * @param userToken
-	 * @param appRole
+	 * @param appRoleUpdate
 	 * @param userDetails
 	 * @return ResponseEntity<String>
 	 */
-	public ResponseEntity<String> updateAppRole(String userToken, AppRole appRole, UserDetails userDetails) {
-		return appRoleService.updateAppRole(userToken, appRole, userDetails);
+	public ResponseEntity<String> updateAppRole(String userToken, AppRoleUpdate appRoleUpdate, UserDetails userDetails) {
+		return appRoleService.updateAppRole(userToken, appRoleUpdate, userDetails);
 	}
 
 	/**

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/utils/CommonUtils.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/utils/CommonUtils.java
@@ -25,9 +25,11 @@ import java.util.List;
 import com.google.common.collect.ImmutableMap;
 import com.tmobile.cso.vault.api.common.TVaultConstants;
 import com.tmobile.cso.vault.api.exception.LogMessage;
+import com.tmobile.cso.vault.api.model.DirectoryUser;
 import com.tmobile.cso.vault.api.model.UserDetails;
 import com.tmobile.cso.vault.api.process.RequestProcessor;
 import com.tmobile.cso.vault.api.process.Response;
+import com.tmobile.cso.vault.api.service.DirectoryService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +46,9 @@ public class CommonUtils {
 
 	@Autowired
 	private RequestProcessor reqProcessor;
+
+	@Autowired
+	private DirectoryService directoryService;
 
 	private Logger log = LogManager.getLogger(CommonUtils.class);
 
@@ -175,6 +180,31 @@ public class CommonUtils {
 			}
 		}
 		return currentpolicies;
+	}
+
+	/**
+	 * Method to get the Directory User details
+	 *
+	 * @param userName
+	 * @return
+	 */
+	public DirectoryUser getUserDetails(String userName) {
+		DirectoryUser directoryUser = directoryService.getUserDetailsByCorpId(userName);
+		if (StringUtils.isEmpty(directoryUser.getUserEmail())) {
+			// Get user details from Corp domain (For sprint users)
+			directoryUser = directoryService.getUserDetailsFromCorp(userName);
+		}
+		if (directoryUser != null) {
+			if(directoryUser.getDisplayName() != null) {
+				String[] displayName = directoryUser.getDisplayName().split(",");
+				if (displayName.length > 1) {
+					directoryUser.setDisplayName(displayName[1] + "  " + displayName[0]);
+				}
+			} else {
+				directoryUser.setDisplayName(userName);
+			}
+		}
+		return directoryUser;
 	}
 
 }

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/utils/EmailUtils.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/utils/EmailUtils.java
@@ -339,6 +339,42 @@ public class EmailUtils {
 	 * @param variables
 	 * @param templateFileName
 	 */
+	public void sendAppRoleHtmlEmalFromTemplate(String from, List<String> to, List<String> cc, String subject,
+												  Map<String, String> variables, String templateFileName) {
+		MimeMessage message = javaMailSender.createMimeMessage();
+		MimeMessageHelper helper;
+		try {
+			helper = new MimeMessageHelper(message,true, "UTF-8");
+			helper.setFrom(from);
+			helper.setTo(to.toArray(new String[to.size()]));
+			if (cc != null) {
+				helper.setCc(cc.toArray(new String[cc.size()]));
+			}
+			helper.setSubject(subject);
+
+			String content = this.templateEngine.process(templateFileName, new Context(Locale.getDefault(), variables));
+			helper.setText(content, true);
+			extractImageBytesFromByteArray(helper);
+			javaMailSender.send(message);
+		} catch (MessagingException|MailSendException e) {
+			log.error(JSONUtil.getJSON(ImmutableMap.<String, String>builder().
+					put(LogMessage.USER, ThreadLocalContext.getCurrentMap().get(LogMessage.USER)).
+					put(LogMessage.ACTION, "sendIAMSvcAccHtmlEmalFromTemplate").
+					put(LogMessage.MESSAGE, "Failed to send email notification to AppRole owner.").
+					put(LogMessage.APIURL, ThreadLocalContext.getCurrentMap().get(LogMessage.APIURL)).
+					build()));
+		}
+	}
+
+	/**
+	 * To send HTML email notification
+	 * @param from
+	 * @param to
+	 * @param cc
+	 * @param subject
+	 * @param variables
+	 * @param templateFileName
+	 */
 	public void sendIAMSvcAccHtmlEmalFromTemplate(String from, List<String> to, List<String> cc, String subject,
 												  Map<String, String> variables, String templateFileName) {
 		MimeMessage message = javaMailSender.createMimeMessage();

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/v2/controller/IAMServiceAccountsController.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/v2/controller/IAMServiceAccountsController.java
@@ -424,7 +424,7 @@ public class IAMServiceAccountsController {
 	@GetMapping(value = "/v2/iamserviceaccounts/{aws_account_id}/{iam_svc_name}/keys", produces = "application/json")
 	public ResponseEntity<String> getListOfIAMServiceAccountAccessKeys(HttpServletRequest request,
 			@RequestHeader(value = "vault-token") String token, @PathVariable("aws_account_id") String awsAccountId,
-			@PathVariable("iam_svc_name") String iamSvcName) {
+			@PathVariable("iam_svc_name") String iamSvcName) throws IOException {
 		UserDetails userDetails = (UserDetails) request.getAttribute(USER_DETAILS_STRING);
 		return iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(token, iamSvcName, awsAccountId, userDetails);
 	}

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/v2/controller/SelfSupportController.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/v2/controller/SelfSupportController.java
@@ -476,14 +476,14 @@ public class SelfSupportController {
 	 * Create AppRole
 	 * @param request
 	 * @param token
-	 * @param appRole
-	 * @return
+	 * @param appRoleUpdate
+	 * @return ResponseEntity
 	 */
 	@ApiOperation(value = "${SelfSupportController.updateAppRole.value}", notes = "${SelfSupportController.updateAppRole.notes}")
 	@PutMapping(value="/v2/ss/approle", consumes="application/json", produces="application/json")
-	public ResponseEntity<String> updateAppRole(HttpServletRequest request, @RequestHeader(value="vault-token") String token, @Valid @RequestBody AppRole appRole){
+	public ResponseEntity<String> updateAppRole(HttpServletRequest request, @RequestHeader(value="vault-token") String token, @Valid @RequestBody AppRoleUpdate appRoleUpdate){
 		UserDetails userDetails = (UserDetails) ((HttpServletRequest) request).getAttribute("UserDetails");
-		return selfSupportService.updateAppRole(token, appRole, userDetails);
+		return selfSupportService.updateAppRole(token, appRoleUpdate, userDetails);
 	}
 
 	/**

--- a/tvaultapi/src/main/resources/swaggernotes.properties
+++ b/tvaultapi/src/main/resources/swaggernotes.properties
@@ -576,6 +576,8 @@ SelfSupportController.listAppRoles.notes=<b>Lists all AppRoles.</b><br>\
 
 SelfSupportController.updateAppRole.value=To update an existing AppRole
 SelfSupportController.updateAppRole.notes=<b>To update an existing AppRole. </b><br>\
+<b>owner: </b>Optional field. If specified, ownership of the AppRole will be transferred to this user.<br>\
+<b>newOwnerEmail: </b>The email belonging to the new owner, if a new owner is specified.\
 <b>shared_to: </b>List of users to have shared access to the AppRole.<br>\
 <b>role_name: </b>Rolename cannot be null or empty. This field contains the role_name for which the permission are getting granted/removed.<br>\
 <b>secret_id_num_uses: </b>secret_id_num_uses should be minimum 0 and maximum 999999999. <br>\

--- a/tvaultapi/src/main/resources/swaggernotes.properties
+++ b/tvaultapi/src/main/resources/swaggernotes.properties
@@ -577,7 +577,7 @@ SelfSupportController.listAppRoles.notes=<b>Lists all AppRoles.</b><br>\
 SelfSupportController.updateAppRole.value=To update an existing AppRole
 SelfSupportController.updateAppRole.notes=<b>To update an existing AppRole. </b><br>\
 <b>owner: </b>Optional field. If specified, ownership of the AppRole will be transferred to this user.<br>\
-<b>newOwnerEmail: </b>The email belonging to the new owner, if a new owner is specified.\
+<b>new_owner_email: </b>The email belonging to the new owner, if a new owner is specified.<br>\
 <b>shared_to: </b>List of users to have shared access to the AppRole.<br>\
 <b>role_name: </b>Rolename cannot be null or empty. This field contains the role_name for which the permission are getting granted/removed.<br>\
 <b>secret_id_num_uses: </b>secret_id_num_uses should be minimum 0 and maximum 999999999. <br>\

--- a/tvaultapi/src/main/resources/templates/AppRoleTransferEmailTemplate.html
+++ b/tvaultapi/src/main/resources/templates/AppRoleTransferEmailTemplate.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <style>
+        .image {
+            border: 1px solid #eee;
+        }
+        .special-text, h4 {
+            color:#f6006e.
+        }
+    </style>
+</head>
+<body>
+    <div>Hello<span data-th-text="${name}"></span>,</div>
+    <br/>
+    <div>This message is to inform you that ownership of AppRole <span class="special-text" data-th-text="${appRoleName}"></span>
+        has transferred from <span data-th-text="${oldOwnerName}"></span> to you.</div>
+    <br/>
+    <div>Thanks,</div>
+    <div>Support team</div>
+</body>
+</html>

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/AppRoleServiceTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/AppRoleServiceTest.java
@@ -4518,7 +4518,7 @@ public class AppRoleServiceTest {
         String[] policies = policiesList.toArray(new String[policiesList.size()]);
         AppRoleUpdate appRoleUpdate = new AppRoleUpdate(role_name, policies, true, 0, 0, 0);
         appRoleUpdate.setOwner("newOwner");
-        appRoleUpdate.setNewOwnerEmail("newOwner@hotmail.com");
+        appRoleUpdate.setNew_owner_email("newOwner@hotmail.com");
         AppRole appRole = constructAppRoleFromUpdateObject(appRoleUpdate);
         String appRoleResponseJson = new ObjectMapper().writeValueAsString(appRole);
         Response appRoleResponse = getMockResponse(HttpStatus.OK, true, appRoleResponseJson);
@@ -5059,7 +5059,7 @@ public class AppRoleServiceTest {
         // END - AppRole exists
         String jsonStr = "{\"role_name\":\"approle1\",\"policies\":[\"default\"],\"bind_secret_id\":true,\"secret_id_num_uses\":\"1\",\"secret_id_ttl\":\"100m\",\"token_num_uses\":0,\"token_ttl\":null,\"token_max_ttl\":null}";
         ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body("{\"errors\":[\"An AppRole cannot be shared with its owner. Please remove owner newOwner from the shared_to field, or change the owner.\"]}");
+                .body("{\"errors\":[\"An AppRole cannot be shared with its owner. Please remove owner newOwner as a shared user, or change the owner.\"]}");
 
         Map<String,Object> appRolesList = new HashMap<>();
         ArrayList<String> arrayList = new ArrayList<>();

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/IAMServiceAccountServiceTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/IAMServiceAccountServiceTest.java
@@ -6966,23 +6966,23 @@ public class IAMServiceAccountServiceTest {
 	}
 	@Test
 	public void test_getListOfIAMServiceAccountAccessKeys_successfully() {
-		String token = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
 
 		// Mock approle permission check
 		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
-		when(reqProcessor.process("/auth/tvault/lookup","{}", token)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("iamportal_admin_policy");
-		try {
-			when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
 
-		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
-		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(token, iamSvcaccName, awsAccountId, getMockUser(false));
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
 	}
 
@@ -6995,13 +6995,13 @@ public class IAMServiceAccountServiceTest {
 		// Mock approle permission check
 		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
 		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("iamportal_admin_policy");
-		try {
-			when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(true));
@@ -7017,13 +7017,14 @@ public class IAMServiceAccountServiceTest {
 		// Mock approle permission check
 		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"default\"]}");
 		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("default");
-		List<String> identityPolicies = new ArrayList<>();
-		identityPolicies.add("r_iamsvcacc_1234567890_testiamsvcacc01");
 
-		when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-		when(iamServiceAccountUtils.getIdentityPoliciesAsListFromTokenLookupJson(Mockito.any(), Mockito.any())).thenReturn(identityPolicies);
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("default");
+		policies.add("r_iamsvcacc_1234567890_testiamsvcacc01");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
@@ -7039,13 +7040,14 @@ public class IAMServiceAccountServiceTest {
 		// Mock approle permission check
 		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"default\"]}");
 		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("default");
-		List<String> identityPolicies = new ArrayList<>();
-		identityPolicies.add("w_iamsvcacc_1234567890_testiamsvcacc01");
 
-		when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-		when(iamServiceAccountUtils.getIdentityPoliciesAsListFromTokenLookupJson(Mockito.any(), Mockito.any())).thenReturn(identityPolicies);
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("default");
+		policies.add("w_iamsvcacc_1234567890_testiamsvcacc01");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
@@ -7053,7 +7055,7 @@ public class IAMServiceAccountServiceTest {
 	}
 
 	@Test
-	public void test_getListOfIAMServiceAccountAccessKeys_io_exception_failure() throws IOException {
+	public void test_getListOfIAMServiceAccountAccessKeys_empty_response_map_failure() {
 		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
@@ -7061,10 +7063,10 @@ public class IAMServiceAccountServiceTest {
 		// Mock approle permission check
 		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
 		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("iamportal_admin_policy");
 
-		when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenThrow(new IOException());
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
@@ -7073,26 +7075,28 @@ public class IAMServiceAccountServiceTest {
 
 	@Test
 	public void test_getListOfIAMServiceAccountAccessKeys_notauthorized_failed() {
-		String token = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
 
 		// Mock approle permission check
-		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
-		when(reqProcessor.process("/auth/tvault/lookup","{}", token)).thenReturn(lookupResponse);
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"default\"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
 		List<String> currentPolicies = new ArrayList<>();
 		currentPolicies.add("default");
-		try {
-			when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("default");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
 		// System under test
 		String expectedResponse = "{\"errors\":[\"Access denied. Not authorized to perform getting the list of IAM service account access keys.\"]}";
 		ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.FORBIDDEN).body(expectedResponse);
 
-		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(token, iamSvcaccName, awsAccountId, getMockUser(false));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
 		assertEquals(responseEntityExpected, responseEntity);
 	}
@@ -7107,17 +7111,15 @@ public class IAMServiceAccountServiceTest {
 		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":" +
 				"[\"r_iamsvcacc_1234567890_testiamsvcacc01, d_iamsvcacc_1234567890_testiamsvcacc01 \"]}");
 		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("default");
-		List<String> identityPolicies = new ArrayList<>();
-		identityPolicies.add("r_iamsvcacc_1234567890_testiamsvcacc01");
-		identityPolicies.add("d_iamsvcacc_1234567890_testiamsvcacc01");
-		try {
-			when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-			when(iamServiceAccountUtils.getIdentityPoliciesAsListFromTokenLookupJson(Mockito.any(), Mockito.any())).thenReturn(identityPolicies);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("default");
+		policies.add("r_iamsvcacc_1234567890_testiamsvcacc01");
+		policies.add("d_iamsvcacc_1234567890_testiamsvcacc01");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
 		// System under test
 		String expectedResponse = "{\"errors\":[\"Access denied. Not authorized to perform getting the list of IAM service account access keys.\"]}";
@@ -7130,23 +7132,23 @@ public class IAMServiceAccountServiceTest {
 
 	@Test
 	public void test_getListOfIAMServiceAccountAccessKeys_failed_Empty() {
-		String token = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
 
 		// Mock approle permission check
 		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
-		when(reqProcessor.process("/auth/tvault/lookup","{}", token)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("iamportal_admin_policy");
-		try {
-			when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
 
-		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(token))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser\",\"secret\":[],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
-		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(token, iamSvcaccName, awsAccountId, getMockUser(false));
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser\",\"secret\":[],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
 	}
 
@@ -7158,13 +7160,13 @@ public class IAMServiceAccountServiceTest {
 
 		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
 		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
-		List<String> currentPolicies = new ArrayList<>();
-		currentPolicies.add("iamportal_admin_policy");
-		try {
-			when(iamServiceAccountUtils.getTokenPoliciesAsListFromTokenLookupJson(Mockito.any(),Mockito.any())).thenReturn(currentPolicies);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(
 				getMockResponse(HttpStatus.NOT_FOUND, false, "{}"));

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/IAMServiceAccountServiceTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/IAMServiceAccountServiceTest.java
@@ -6965,7 +6965,7 @@ public class IAMServiceAccountServiceTest {
 		assertEquals(responseEntityExpected, responseEntityActual);
 	}
 	@Test
-	public void test_getListOfIAMServiceAccountAccessKeys_successfully() {
+	public void test_getListOfIAMServiceAccountAccessKeys_successfully() throws IOException {
 		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
@@ -6980,6 +6980,9 @@ public class IAMServiceAccountServiceTest {
 		policies.add("iamportal_admin_policy");
 		dataMap.put("policies", policies);
 		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
 
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
@@ -6987,7 +6990,7 @@ public class IAMServiceAccountServiceTest {
 	}
 
 	@Test
-	public void test_getListOfIAMServiceAccountAccessKeys_as_admin_successfully() {
+	public void test_getListOfIAMServiceAccountAccessKeys_as_admin_successfully() throws IOException {
 		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
@@ -7002,6 +7005,9 @@ public class IAMServiceAccountServiceTest {
 		policies.add("iamportal_admin_policy");
 		dataMap.put("policies", policies);
 		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
 
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(true));
@@ -7026,6 +7032,9 @@ public class IAMServiceAccountServiceTest {
 		dataMap.put("policies", policies);
 		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
@@ -7049,13 +7058,195 @@ public class IAMServiceAccountServiceTest {
 		dataMap.put("policies", policies);
 		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
 	}
 
 	@Test
-	public void test_getListOfIAMServiceAccountAccessKeys_empty_response_map_failure() {
+	public void test_getListOfIAMServiceAccountAccessKeys_with_approle_success() throws IOException {
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String iamSvcaccName = "testiamsvcacc01";
+		String awsAccountId = "1234567890";
+		UserDetails userDetails = getMockUser(false);
+
+		// Mock approle permission check
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"app-roles\":{\"approle1\":\"read\"}, \"aws-roles\": {\"aws123\": \"read\"}, \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
+		Map<String, Object> appRoleMap = new HashMap<>();
+		appRoleMap.put("approle1", "read");
+		when(ControllerUtil.parseJson("{\"approle1\":\"read\"}")).thenReturn(appRoleMap);
+
+		AppRoleMetadata appRoleMetadata = new AppRoleMetadata();
+		AppRoleMetadataDetails appRoleMetadataDetails = new AppRoleMetadataDetails();
+		appRoleMetadataDetails.setCreatedBy(userDetails.getUsername());
+		appRoleMetadata.setAppRoleMetadataDetails(appRoleMetadataDetails);
+		when(appRoleService.readAppRoleMetadata(Mockito.any(), Mockito.any())).thenReturn(appRoleMetadata);
+
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, userDetails);
+		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void test_getListOfIAMServiceAccountAccessKeys_with_awsrole_success() throws IOException {
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String iamSvcaccName = "testiamsvcacc01";
+		String awsAccountId = "1234567890";
+		UserDetails userDetails = getMockUser(false);
+
+		// Mock approle permission check
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"app-roles\":{\"approle1\":\"read\"}, \"aws-roles\": {\"aws123\": \"read\"}, \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
+		Map<String, Object> appRoleMap = new HashMap<>();
+		appRoleMap.put("approle1", "read");
+		when(ControllerUtil.parseJson("{\"approle1\":\"read\"}")).thenReturn(appRoleMap);
+
+		AppRoleMetadata appRoleMetadata = new AppRoleMetadata();
+		AppRoleMetadataDetails appRoleMetadataDetails = new AppRoleMetadataDetails();
+		appRoleMetadataDetails.setCreatedBy("aPerson");
+		appRoleMetadata.setAppRoleMetadataDetails(appRoleMetadataDetails);
+		when(appRoleService.readAppRoleMetadata(Mockito.any(), Mockito.any())).thenReturn(appRoleMetadata);
+
+		Map<String, Object> awsRoleMap = new HashMap<>();
+		awsRoleMap.put("awsrole1", "write");
+		when(ControllerUtil.parseJson("{\"aws123\":\"read\"}")).thenReturn(awsRoleMap);
+
+		when(reqProcessor.process(Mockito.eq("/read"), Mockito.eq("{\"path\":\"metadata/awsrole/awsrole1\"}"), Mockito.any()))
+				.thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"createdBy\":\"normaluser\",\"name\":\"test\",\"sharedTo\":null}}"));
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, userDetails);
+		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void test_getListOfIAMServiceAccountAccessKeys_with_approle_deny_failure() throws IOException {
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String iamSvcaccName = "testiamsvcacc01";
+		String awsAccountId = "1234567890";
+		UserDetails userDetails = getMockUser(false);
+
+		// Mock approle permission check
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"app-roles\":{\"approle1\":\"deny\"}, \"aws-roles\": {\"aws123\": \"read\"}, \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
+		Map<String, Object> appRoleMap = new HashMap<>();
+		appRoleMap.put("approle1", "deny");
+		when(ControllerUtil.parseJson("{\"approle1\":\"deny\"}")).thenReturn(appRoleMap);
+
+		AppRoleMetadata appRoleMetadata = new AppRoleMetadata();
+		AppRoleMetadataDetails appRoleMetadataDetails = new AppRoleMetadataDetails();
+		appRoleMetadataDetails.setCreatedBy(userDetails.getUsername());
+		appRoleMetadata.setAppRoleMetadataDetails(appRoleMetadataDetails);
+		when(appRoleService.readAppRoleMetadata(Mockito.any(), Mockito.any())).thenReturn(appRoleMetadata);
+
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, userDetails);
+		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void test_getListOfIAMServiceAccountAccessKeys_with_awsrole_deny_failure() throws IOException {
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String iamSvcaccName = "testiamsvcacc01";
+		String awsAccountId = "1234567890";
+		UserDetails userDetails = getMockUser(false);
+
+		// Mock approle permission check
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"app-roles\":{\"approle1\":\"read\"}, \"aws-roles\": {\"aws123\": \"deny\"}, \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
+		Map<String, Object> awsRoleMap = new HashMap<>();
+		awsRoleMap.put("awsrole1", "deny");
+		when(ControllerUtil.parseJson("{\"aws123\":\"deny\"}")).thenReturn(awsRoleMap);
+
+		when(reqProcessor.process(Mockito.eq("/read"), Mockito.eq("{\"path\":\"metadata/awsrole/awsrole1\"}"), Mockito.any()))
+				.thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"createdBy\":\"normaluser\",\"name\":\"test\",\"sharedTo\":null}}"));
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, userDetails);
+		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void test_getListOfIAMServiceAccountAccessKeys_with_approle_null_metadata_failure() throws IOException {
+		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+		String iamSvcaccName = "testiamsvcacc01";
+		String awsAccountId = "1234567890";
+
+		// Mock approle permission check
+		Response lookupResponse = getMockResponse(HttpStatus.OK, true, "{\"policies\":[\"iamportal_admin_policy \"]}");
+		when(reqProcessor.process("/auth/tvault/lookup","{}", tkn)).thenReturn(lookupResponse);
+
+		when(OIDCUtil.renewUserToken(tkn)).thenReturn(lookupResponse);
+		Map<String, Object> dataMap = new HashMap<>();
+		List<String> policies = new ArrayList<>();
+		policies.add("iamportal_admin_policy");
+		dataMap.put("policies", policies);
+		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"app-roles\":{\"approle1\":\"read\"}, \"aws-roles\": {\"aws123\": \"read\"}, \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
+		Map<String, Object> appRoleMap = new HashMap<>();
+		appRoleMap.put("approle1", "read");
+		when(ControllerUtil.parseJson("{\"approle1\":\"read\"}")).thenReturn(appRoleMap);
+
+		Map<String, Object> awsRoleMap = new HashMap<>();
+		appRoleMap.put("awsrole1", "write");
+		when(ControllerUtil.parseJson("{\"aws123\":\"read\"}")).thenReturn(awsRoleMap);
+
+		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
+		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
+		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+	}
+
+	@Test
+	public void test_getListOfIAMServiceAccountAccessKeys_empty_response_map_failure() throws IOException {
 		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
@@ -7068,13 +7259,16 @@ public class IAMServiceAccountServiceTest {
 		Map<String, Object> dataMap = new HashMap<>();
 		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser1\",\"secret\":[{\"accessKeyId\":\"1212zdasd\",\"expiryDuration\":\"1086073200000\"}],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
 	}
 
 	@Test
-	public void test_getListOfIAMServiceAccountAccessKeys_notauthorized_failed() {
+	public void test_getListOfIAMServiceAccountAccessKeys_notauthorized_failed() throws IOException {
 		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
@@ -7096,13 +7290,16 @@ public class IAMServiceAccountServiceTest {
 		String expectedResponse = "{\"errors\":[\"Access denied. Not authorized to perform getting the list of IAM service account access keys.\"]}";
 		ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.FORBIDDEN).body(expectedResponse);
 
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
 		assertEquals(responseEntityExpected, responseEntity);
 	}
 
 	@Test
-	public void test_getListOfIAMServiceAccountAccessKeys_deny_failed() {
+	public void test_getListOfIAMServiceAccountAccessKeys_deny_failed() throws IOException {
 		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
@@ -7125,13 +7322,16 @@ public class IAMServiceAccountServiceTest {
 		String expectedResponse = "{\"errors\":[\"Access denied. Not authorized to perform getting the list of IAM service account access keys.\"]}";
 		ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.FORBIDDEN).body(expectedResponse);
 
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
 		assertEquals(responseEntityExpected, responseEntity);
 	}
 
 	@Test
-	public void test_getListOfIAMServiceAccountAccessKeys_failed_Empty() {
+	public void test_getListOfIAMServiceAccountAccessKeys_failed_Empty() throws IOException {
 		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
@@ -7147,13 +7347,16 @@ public class IAMServiceAccountServiceTest {
 		dataMap.put("policies", policies);
 		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
 
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
+
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(getMockResponse(HttpStatus.OK, true, "{\"data\":{\"app-roles\":{\"selfserviceoidcsupportrole\":\"read\"},\"application_id\":1222,\"application_name\":\"T-Vault\",\"application_tag\":\"TVT\",\"awsAccountId\":\"123456789012\",\"awsAccountName\":\"AWS-SEC\",\"createdAtEpoch\":1086073200000,\"isActivated\":true,\"owner_email\":\"test.test1@T-mobile.com\",\"owner_ntid\":\"testuser\",\"secret\":[],\"userName\":\"testiamsvcacc01\",\"users\":{\"testuser1\":\"write\"}}}"));
 		ResponseEntity<String> responseEntity = iamServiceAccountsService.getListOfIAMServiceAccountAccessKeys(tkn, iamSvcaccName, awsAccountId, getMockUser(false));
 		assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
 	}
 
 	@Test
-	public void test_getListOfIAMServiceAccountAccessKeys_no_account_found_failure() {
+	public void test_getListOfIAMServiceAccountAccessKeys_no_account_found_failure() throws IOException {
 		String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
 		String iamSvcaccName = "testiamsvcacc01";
 		String awsAccountId = "1234567890";
@@ -7167,6 +7370,9 @@ public class IAMServiceAccountServiceTest {
 		policies.add("iamportal_admin_policy");
 		dataMap.put("policies", policies);
 		when(ControllerUtil.parseJson(lookupResponse.getResponse())).thenReturn(dataMap);
+
+		String iamMetaDataStr = "{ \"data\": {\"userName\": \"testiamsvcacc01\", \"awsAccountId\": \"1234567890\", \"awsAccountName\": \"testaccount1\", \"createdAtEpoch\": 1609754282000, \"owner_ntid\": \"normaluser\", \"owner_email\": \"normaluser@testmail.com\", \"application_id\": \"app1\", \"application_name\": \"App1\", \"application_tag\": \"App1\", \"isActivated\": true, \"secret\":[]}, \"path\": \"iamsvcacc/1234567890_svc_vault_test5\"}";
+		when(reqProcessor.process("/read", "{\"path\":\"metadata/iamsvcacc/1234567890_testiamsvcacc01\"}", tkn)).thenReturn(getMockResponse(HttpStatus.OK, true, iamMetaDataStr));
 
 		when(reqProcessor.process(eq("/iamsvcacct"),Mockito.any(),eq(tkn))).thenReturn(
 				getMockResponse(HttpStatus.NOT_FOUND, false, "{}"));

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/SelfSupportServiceTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/SelfSupportServiceTest.java
@@ -3848,8 +3848,8 @@ public class SelfSupportServiceTest {
         UserDetails userDetails = getMockUser(false);
         String roleName = "myvaultapprole42";
         String [] policies = {"s_shared_s1"};
-        AppRole appRole = new AppRole("approle1", policies, true, 1, 100, 0);
-        ResponseEntity<String> responseEntity = selfSupportService.updateAppRole(sampletok, appRole, userDetails);
+        AppRoleUpdate appRoleUpdate = new AppRoleUpdate("approle1", policies, true, 1, 100, 0);
+        ResponseEntity<String> responseEntity = selfSupportService.updateAppRole(sampletok, appRoleUpdate, userDetails);
         assertTrue(true);
     }
     @Test

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/v2/controller/SelfSupportControllerTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/v2/controller/SelfSupportControllerTest.java
@@ -715,7 +715,7 @@ public class SelfSupportControllerTest {
         String responseMessage = "{\"messages\":[\"AppRole updated successfully \"]}";
         ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(responseMessage);
         UserDetails userDetails = getMockUser(false);
-        when(selfSupportService.updateAppRole(eq("5PDrOhsy4ig8L3EpsJZSLAMg"), Mockito.any(AppRole.class), eq(userDetails))).thenReturn(responseEntityExpected);
+        when(selfSupportService.updateAppRole(eq("5PDrOhsy4ig8L3EpsJZSLAMg"), Mockito.any(AppRoleUpdate.class), eq(userDetails))).thenReturn(responseEntityExpected);
 
         String tkn = "vault-token";
         mockMvc.perform(MockMvcRequestBuilders.put("/v2/ss/approle").requestAttr("UserDetails", userDetails)


### PR DESCRIPTION
Updates to updateAppRole method that allow the transferring of an AppRole from one user to another. Also included is a fix for the following IAM Service Account issue - 
  _IAM Service Account owned by normal/admin user and given 'read'/'write' permission to other user via group
  With the token of other user try to hit the get all access keys api
  Getting error as : "Access denied. Not authorized to perform getting the list of IAM service account access keys."
  But it should List the access keys._