### PR TITLE
T-Vault: Add UI Indicator for AppRoles Owned by Logged In User

### DIFF
--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/AppRoleDetails.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/AppRoleDetails.java
@@ -17,6 +17,8 @@
 
 package com.tmobile.cso.vault.api.model;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import java.io.Serializable;
 
 
@@ -27,72 +29,113 @@ public class AppRoleDetails implements Serializable {
 	 */
 	private static final long serialVersionUID = 6360594229180017552L;
 
-	private AppRole appRole;
+	private String role_name;
+	private String[] policies;
+	private boolean bind_secret_id;
+	@Min(0)
+	@Max(999999999)
+	private Integer secret_id_num_uses;
+	@Min(0)
+	@Max(999999999)
+	private Integer secret_id_ttl;
+	@Min(0)
+	@Max(999999999)
+	private Integer token_num_uses;
+	@Min(0)
+	@Max(999999999)
+	private Integer token_ttl;
+	@Min(0)
+	@Max(999999999)
+	private Integer token_max_ttl;
 	private String role_id;
 	private String[] accessorIds;
 	private AppRoleMetadata appRoleMetadata;
-	
-	/**
-	 * 
-	 */
-	public AppRoleDetails() {
-		
+
+	public String getRole_name() {
+		return role_name;
 	}
 
-	/**
-	 * @return the appRole
-	 */
-	public AppRole getAppRole() {
-		return appRole;
+	public void setRole_name(String role_name) {
+		this.role_name = role_name;
 	}
 
-	/**
-	 * @return the role_id
-	 */
+	public String[] getPolicies() {
+		return policies;
+	}
+
+	public void setPolicies(String[] policies) {
+		this.policies = policies;
+	}
+
+	public boolean isBind_secret_id() {
+		return bind_secret_id;
+	}
+
+	public void setBind_secret_id(boolean bind_secret_id) {
+		this.bind_secret_id = bind_secret_id;
+	}
+
+	public Integer getSecret_id_num_uses() {
+		return secret_id_num_uses;
+	}
+
+	public void setSecret_id_num_uses(Integer secret_id_num_uses) {
+		this.secret_id_num_uses = secret_id_num_uses;
+	}
+
+	public Integer getSecret_id_ttl() {
+		return secret_id_ttl;
+	}
+
+	public void setSecret_id_ttl(Integer secret_id_ttl) {
+		this.secret_id_ttl = secret_id_ttl;
+	}
+
+	public Integer getToken_num_uses() {
+		return token_num_uses;
+	}
+
+	public void setToken_num_uses(Integer token_num_uses) {
+		this.token_num_uses = token_num_uses;
+	}
+
+	public Integer getToken_ttl() {
+		return token_ttl;
+	}
+
+	public void setToken_ttl(Integer token_ttl) {
+		this.token_ttl = token_ttl;
+	}
+
+	public Integer getToken_max_ttl() {
+		return token_max_ttl;
+	}
+
+	public void setToken_max_ttl(Integer token_max_ttl) {
+		this.token_max_ttl = token_max_ttl;
+	}
+
 	public String getRole_id() {
 		return role_id;
 	}
 
-	/**
-	 * @return the appRoleMetadata
-	 */
-	public AppRoleMetadata getAppRoleMetadata() {
-		return appRoleMetadata;
-	}
-
-	/**
-	 * @param appRole the appRole to set
-	 */
-	public void setAppRole(AppRole appRole) {
-		this.appRole = appRole;
-	}
-
-	/**
-	 * @param role_id the role_id to set
-	 */
 	public void setRole_id(String role_id) {
 		this.role_id = role_id;
 	}
 
-	/**
-	 * @param appRoleMetadata the appRoleMetadata to set
-	 */
-	public void setAppRoleMetadata(AppRoleMetadata appRoleMetadata) {
-		this.appRoleMetadata = appRoleMetadata;
-	}
-
-	/**
-	 * @return the accessorIds
-	 */
 	public String[] getAccessorIds() {
 		return accessorIds;
 	}
 
-	/**
-	 * @param accessorIds the accessorIds to set
-	 */
 	public void setAccessorIds(String[] accessorIds) {
 		this.accessorIds = accessorIds;
 	}
 
+	public AppRoleMetadata getAppRoleMetadata() {
+		return appRoleMetadata;
+	}
+
+	public void setAppRoleMetadata(AppRoleMetadata appRoleMetadata) {
+		this.appRoleMetadata = appRoleMetadata;
+	}
 }

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/AppRoleListObject.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/model/AppRoleListObject.java
@@ -1,0 +1,32 @@
+package com.tmobile.cso.vault.api.model;
+
+import java.io.Serializable;
+
+public class AppRoleListObject implements Serializable {
+
+    private String roleName;
+    private boolean isOwner;
+
+    public AppRoleListObject() {}
+
+    public AppRoleListObject(String roleName, boolean isOwner) {
+        this.roleName = roleName;
+        this.isOwner = isOwner;
+    }
+
+    public String getRoleName() {
+        return roleName;
+    }
+
+    public void setRoleName(String roleName) {
+        this.roleName = roleName;
+    }
+
+    public boolean isOwner() {
+        return isOwner;
+    }
+
+    public void setOwner(boolean owner) {
+        isOwner = owner;
+    }
+}

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/SelfSupportService.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/service/SelfSupportService.java
@@ -918,7 +918,7 @@ public class  SelfSupportService {
 	 * @param userDetails
 	 * @return
 	 */
-	public ResponseEntity<String> listAppRoles(String userToken, UserDetails userDetails, Integer limit, Integer offset) {
+	public ResponseEntity<List<AppRoleListObject>> listAppRoles(String userToken, UserDetails userDetails, Integer limit, Integer offset) {
 		return appRoleService.listAppRoles(userToken, userDetails, limit, offset);
 	}
 

--- a/tvaultapi/src/main/java/com/tmobile/cso/vault/api/v2/controller/SelfSupportController.java
+++ b/tvaultapi/src/main/java/com/tmobile/cso/vault/api/v2/controller/SelfSupportController.java
@@ -34,6 +34,8 @@ import com.tmobile.cso.vault.api.service.SelfSupportService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
+import java.util.List;
+
 @RestController
 @CrossOrigin
 @Api(description = "Manage Safes/SDBs", position = 21)
@@ -426,8 +428,8 @@ public class SelfSupportController {
 	 */
 	@ApiOperation(value = "${SelfSupportController.listAppRoles.value}", notes = "${SelfSupportController.listAppRoles.notes}")
 	@GetMapping (value="/v2/ss/approle",produces="application/json")
-	public ResponseEntity<String> listAppRoles(HttpServletRequest request, @RequestHeader(value="vault-token") String token, 
-			@RequestParam(name = "limit", required = false) Integer limit, @RequestParam(name = "offset", required = false) Integer offset){
+	public ResponseEntity<List<AppRoleListObject>> listAppRoles(HttpServletRequest request, @RequestHeader(value="vault-token") String token,
+																@RequestParam(name = "limit", required = false) Integer limit, @RequestParam(name = "offset", required = false) Integer offset){
 		UserDetails userDetails = (UserDetails) ((HttpServletRequest) request).getAttribute("UserDetails");
 		return selfSupportService.listAppRoles(token, userDetails, limit, offset);	
 	}

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/AppRoleServiceTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/AppRoleServiceTest.java
@@ -2140,45 +2140,202 @@ public class AppRoleServiceTest {
     }
 
     @Test
-    public void test_listAppRoles_successfully() {
-        String token = "5PDrOhsy4ig8L3EpsJZSLAMg";
-        String responseJson = "{\r\n" + 
-        		"  \"keys\": [\r\n" + 
-        		"    \"testapprole01\"\r\n" + 
-        		"  ]\r\n" + 
+    public void test_listAppRoles_successfully() throws JsonProcessingException {
+        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+        String responseJson = "{\r\n" +
+        		"  \"keys\": [\r\n" +
+        		"    \"testapprole01\"\r\n" +
+        		"  ]\r\n" +
         		"}";
-        ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(responseJson);
+        AppRoleListObject appRoleListObject = new AppRoleListObject();
+        appRoleListObject.setRoleName("testapprole01");
+        appRoleListObject.setOwner(true);
+        List<AppRoleListObject> appRoleListObjects = new ArrayList<>();
+        appRoleListObjects.add(appRoleListObject);
+        ResponseEntity<List<AppRoleListObject>> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(appRoleListObjects);
         UserDetails userDetails = getMockUser("testuser1", false);
-        Response response =getMockResponse(HttpStatus.OK, true, responseJson);
+        Response response = getMockResponse(HttpStatus.OK, true, responseJson);
         Response responseAfterHide = response;
         String _path = "metadata/approle_users/" + userDetails.getUsername();
         String jsonStr = "{\"path\":\""+_path+"\"}";
-        when(reqProcessor.process("/auth/approles/rolesbyuser/list", jsonStr,userDetails.getSelfSupportToken())).thenReturn(response);
-        when(ControllerUtil.hideSelfSupportAdminAppRoleFromResponse(Mockito.any(),Mockito.any(), Mockito.any())).thenReturn(responseAfterHide);
-        ResponseEntity<String> responseEntityActual = appRoleService.listAppRoles(token, userDetails, 1, 0);
-        assertEquals(HttpStatus.OK, responseEntityActual.getStatusCode());
-        assertEquals(responseEntityExpected, responseEntityActual);
+        when(reqProcessor.process("/auth/approles/rolesbyuser/list", jsonStr, userDetails.getSelfSupportToken()))
+                .thenReturn(response);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        List<String> keys = new ArrayList<>();
+        keys.add("testapprole01");
+        responseMap.put("keys", keys);
+        when(ControllerUtil.parseJson(any())).thenReturn(responseMap);
+
+        AppRoleMetadata approleMetadataExpected = new AppRoleMetadata();
+        approleMetadataExpected.setPath(_path);
+        AppRoleMetadataDetails appRoleMetadataDetails = new AppRoleMetadataDetails();
+        appRoleMetadataDetails.setCreatedBy("testuser1");
+        appRoleMetadataDetails.setName("testapprole01");
+        approleMetadataExpected.setAppRoleMetadataDetails(appRoleMetadataDetails);
+
+        String readResponseJson = new ObjectMapper().writeValueAsString(approleMetadataExpected);
+        Response readResponse = getMockResponse(HttpStatus.OK, true, readResponseJson);
+        when(reqProcessor.process(eq("/read"), any(), any())).thenReturn(readResponse);
+
+        Map<String, Object> readResponseMap = new HashMap<>();
+        Map<String, Object> appRoleMetadataMap = new HashMap<>();
+        appRoleMetadataMap.put("createdBy", userDetails.getUsername());
+        readResponseMap.put("data", appRoleMetadataMap);
+        when(ControllerUtil.parseJson(readResponseJson)).thenReturn(readResponseMap);
+
+        when(ControllerUtil.hideSelfSupportAdminAppRoleFromResponse(Mockito.any(),Mockito.any(), Mockito.any()))
+                .thenReturn(responseAfterHide);
+        ResponseEntity<List<AppRoleListObject>> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
+        assertEquals(responseEntityExpected.getStatusCode(), responseEntityActual.getStatusCode());
+        assertEquals(responseEntityExpected.getBody().get(0).getRoleName(), responseEntityActual.getBody().get(0).getRoleName());
     }
 
     @Test
-    public void test_listAppRoles_as_admin_successfully() {
+    public void test_listAppRoles_as_admin_successfully() throws JsonProcessingException {
         String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
         String responseJson = "{\r\n" +
                 "  \"keys\": [\r\n" +
                 "    \"testapprole01\"\r\n" +
                 "  ]\r\n" +
                 "}";
-        ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(responseJson);
+        AppRoleListObject appRoleListObject = new AppRoleListObject();
+        appRoleListObject.setRoleName("testapprole01");
+        appRoleListObject.setOwner(true);
+        List<AppRoleListObject> appRoleListObjects = new ArrayList<>();
+        appRoleListObjects.add(appRoleListObject);
+        ResponseEntity<List<AppRoleListObject>> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(appRoleListObjects);
         UserDetails userDetails = getMockUser("testuser1", true);
-        Response response =getMockResponse(HttpStatus.OK, true, responseJson);
+        Response response = getMockResponse(HttpStatus.OK, true, responseJson);
         Response responseAfterHide = response;
         String _path = "metadata/approle_users/" + userDetails.getUsername();
         String jsonStr = "{\"path\":\""+_path+"\"}";
         when(reqProcessor.process("/auth/approle/role/list", jsonStr, tkn)).thenReturn(response);
         when(ControllerUtil.hideSelfSupportAdminAppRoleFromResponse(Mockito.any(),Mockito.any(), Mockito.any())).thenReturn(responseAfterHide);
-        ResponseEntity<String> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
-        assertEquals(HttpStatus.OK, responseEntityActual.getStatusCode());
-        assertEquals(responseEntityExpected, responseEntityActual);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        List<String> keys = new ArrayList<>();
+        keys.add("testapprole01");
+        responseMap.put("keys", keys);
+        when(ControllerUtil.parseJson(any())).thenReturn(responseMap);
+
+        AppRoleMetadata approleMetadataExpected = new AppRoleMetadata();
+        approleMetadataExpected.setPath(_path);
+        AppRoleMetadataDetails appRoleMetadataDetails = new AppRoleMetadataDetails();
+        appRoleMetadataDetails.setCreatedBy("testuser1");
+        appRoleMetadataDetails.setName("testapprole01");
+        approleMetadataExpected.setAppRoleMetadataDetails(appRoleMetadataDetails);
+
+        String readResponseJson = new ObjectMapper().writeValueAsString(approleMetadataExpected);
+        Response readResponse = getMockResponse(HttpStatus.OK, true, readResponseJson);
+        when(reqProcessor.process(eq("/read"), any(), any())).thenReturn(readResponse);
+
+        Map<String, Object> readResponseMap = new HashMap<>();
+        Map<String, Object> appRoleMetadataMap = new HashMap<>();
+        appRoleMetadataMap.put("createdBy", userDetails.getUsername());
+        readResponseMap.put("data", appRoleMetadataMap);
+        when(ControllerUtil.parseJson(readResponseJson)).thenReturn(readResponseMap);
+
+        when(ControllerUtil.hideSelfSupportAdminAppRoleFromResponse(Mockito.any(),Mockito.any(), Mockito.any()))
+                .thenReturn(responseAfterHide);
+        ResponseEntity<List<AppRoleListObject>> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
+        assertEquals(responseEntityExpected.getStatusCode(), responseEntityActual.getStatusCode());
+        assertEquals(responseEntityExpected.getBody().get(0).getRoleName(), responseEntityActual.getBody().get(0).getRoleName());
+    }
+
+    @Test
+    public void test_listAppRoles_empty_response_failure() throws JsonProcessingException {
+        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+        String responseJson = "{\r\n" +
+                "  \"keys\": [\r\n" +
+                "    \"testapprole01\"\r\n" +
+                "  ]\r\n" +
+                "}";
+        AppRoleListObject appRoleListObject = new AppRoleListObject();
+        appRoleListObject.setRoleName("testapprole01");
+        appRoleListObject.setOwner(true);
+        List<AppRoleListObject> appRoleListObjects = new ArrayList<>();
+        appRoleListObjects.add(appRoleListObject);
+        ResponseEntity<List<AppRoleListObject>> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(appRoleListObjects);
+        UserDetails userDetails = getMockUser("testuser1", false);
+        Response response = getMockResponse(HttpStatus.OK, true, responseJson);
+        Response responseAfterHide = response;
+        String _path = "metadata/approle_users/" + userDetails.getUsername();
+        String jsonStr = "{\"path\":\""+_path+"\"}";
+        when(reqProcessor.process("/auth/approles/rolesbyuser/list", jsonStr, userDetails.getSelfSupportToken()))
+                .thenReturn(response);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        when(ControllerUtil.parseJson(any())).thenReturn(responseMap);
+
+        AppRoleMetadata approleMetadataExpected = new AppRoleMetadata();
+        approleMetadataExpected.setPath(_path);
+        AppRoleMetadataDetails appRoleMetadataDetails = new AppRoleMetadataDetails();
+        appRoleMetadataDetails.setCreatedBy("testuser1");
+        appRoleMetadataDetails.setName("testapprole01");
+        approleMetadataExpected.setAppRoleMetadataDetails(appRoleMetadataDetails);
+
+        String readResponseJson = new ObjectMapper().writeValueAsString(approleMetadataExpected);
+        Response readResponse = getMockResponse(HttpStatus.OK, true, readResponseJson);
+        when(reqProcessor.process(eq("/read"), any(), any())).thenReturn(readResponse);
+
+        Map<String, Object> readResponseMap = new HashMap<>();
+        Map<String, Object> appRoleMetadataMap = new HashMap<>();
+        appRoleMetadataMap.put("createdBy", userDetails.getUsername());
+        readResponseMap.put("data", appRoleMetadataMap);
+        when(ControllerUtil.parseJson(readResponseJson)).thenReturn(readResponseMap);
+
+        when(ControllerUtil.hideSelfSupportAdminAppRoleFromResponse(Mockito.any(),Mockito.any(), Mockito.any()))
+                .thenReturn(responseAfterHide);
+        ResponseEntity<List<AppRoleListObject>> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
+        assertEquals(responseEntityExpected.getStatusCode(), responseEntityActual.getStatusCode());
+        assertTrue(responseEntityActual.getBody().isEmpty());
+    }
+
+    @Test
+    public void test_listAppRoles_null_metadata_failure() throws JsonProcessingException {
+        String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+        String responseJson = "{\r\n" +
+                "  \"keys\": [\r\n" +
+                "    \"testapprole01\"\r\n" +
+                "  ]\r\n" +
+                "}";
+        AppRoleListObject appRoleListObject = new AppRoleListObject();
+        appRoleListObject.setRoleName("testapprole01");
+        appRoleListObject.setOwner(true);
+        List<AppRoleListObject> appRoleListObjects = new ArrayList<>();
+        appRoleListObjects.add(appRoleListObject);
+        ResponseEntity<List<AppRoleListObject>> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(appRoleListObjects);
+        UserDetails userDetails = getMockUser("testuser1", false);
+        Response response = getMockResponse(HttpStatus.OK, true, responseJson);
+        Response responseAfterHide = response;
+        String _path = "metadata/approle_users/" + userDetails.getUsername();
+        String jsonStr = "{\"path\":\""+_path+"\"}";
+        when(reqProcessor.process("/auth/approles/rolesbyuser/list", jsonStr, userDetails.getSelfSupportToken()))
+                .thenReturn(response);
+
+        Map<String, Object> responseMap = new HashMap<>();
+        List<String> keys = new ArrayList<>();
+        keys.add("testapprole01");
+        responseMap.put("keys", keys);
+        when(ControllerUtil.parseJson(any())).thenReturn(responseMap);
+
+        AppRoleMetadata approleMetadataExpected = new AppRoleMetadata();
+        approleMetadataExpected.setPath(_path);
+        AppRoleMetadataDetails appRoleMetadataDetails = new AppRoleMetadataDetails();
+        appRoleMetadataDetails.setCreatedBy("testuser1");
+        appRoleMetadataDetails.setName("testapprole01");
+        approleMetadataExpected.setAppRoleMetadataDetails(appRoleMetadataDetails);
+
+        String readResponseJson = new ObjectMapper().writeValueAsString(approleMetadataExpected);
+        Response readResponse = getMockResponse(HttpStatus.NOT_FOUND, true, readResponseJson);
+        when(reqProcessor.process(eq("/read"), any(), any())).thenReturn(readResponse);
+
+        when(ControllerUtil.hideSelfSupportAdminAppRoleFromResponse(Mockito.any(),Mockito.any(), Mockito.any()))
+                .thenReturn(responseAfterHide);
+        ResponseEntity<List<AppRoleListObject>> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
+        assertEquals(responseEntityExpected.getStatusCode(), responseEntityActual.getStatusCode());
+        assertTrue(responseEntityActual.getBody().isEmpty());
     }
 
     @Test
@@ -2189,38 +2346,36 @@ public class AppRoleServiceTest {
                 "    \"\"\r\n" +
                 "  \r\n" +
                 "}";
-        ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body("{\"keys\":[]}");
         UserDetails userDetails = getMockUser("testuser1", false);
         Response response = getMockResponse(HttpStatus.NOT_FOUND, false, responseJson);
         String _path = "metadata/approle_users/" + userDetails.getUsername();
         String jsonStr = "{\"path\":\""+_path+"\"}";
         when(reqProcessor.process("/auth/approles/rolesbyuser/list", jsonStr,userDetails.getSelfSupportToken())).thenReturn(response);
         when(ControllerUtil.hideSelfSupportAdminAppRoleFromResponse(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(response);
-        ResponseEntity<String> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
-        assertEquals(HttpStatus.OK, responseEntityActual.getStatusCode());
-        assertEquals(responseEntityExpected, responseEntityActual);
+
+        ResponseEntity<List<AppRoleListObject>> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
+        assertTrue(responseEntityActual.getBody().isEmpty());
     }
-    
+
     @Test
     public void test_listAppRoles_bad_request_failure() {
         String tkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
-        String responseJson = "{\r\n" + 
-        		"  \"error\": \r\n" + 
-        		"    \"\"\r\n" + 
-        		"  \r\n" + 
+        String responseJson = "{\r\n" +
+        		"  \"error\": \r\n" +
+        		"    \"\"\r\n" +
+        		"  \r\n" +
         		"}";
-        ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseJson);
         UserDetails userDetails = getMockUser("testuser1", false);
         Response response =getMockResponse(HttpStatus.BAD_REQUEST, true, responseJson);
         String _path = "metadata/approle_users/" + userDetails.getUsername();
         String jsonStr = "{\"path\":\""+_path+"\"}";
         when(reqProcessor.process("/auth/approles/rolesbyuser/list", jsonStr,userDetails.getSelfSupportToken())).thenReturn(response);
         when(ControllerUtil.hideSelfSupportAdminAppRoleFromResponse(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(response);
-        ResponseEntity<String> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
+        ResponseEntity<List<AppRoleListObject>> responseEntityActual = appRoleService.listAppRoles(tkn, userDetails, 1, 0);
         assertEquals(HttpStatus.BAD_REQUEST, responseEntityActual.getStatusCode());
-        assertEquals(responseEntityExpected, responseEntityActual);
+        assertTrue(responseEntityActual.getBody().isEmpty());
     }
-    
+
     @Test
     public void test_readRoleId_successfully() {
         String token = "5PDrOhsy4ig8L3EpsJZSLAMg";
@@ -3613,7 +3768,14 @@ public class AppRoleServiceTest {
         when(reqProcessor.process("/auth/approle/role/accessors/list", "{\"role_name\":\""+role_name+"\"}",token)).thenReturn(accessorIdResponse);
         
 		AppRoleDetails appRoleDetails = new AppRoleDetails();
-		appRoleDetails.setAppRole(appRole);
+        appRoleDetails.setRole_name(appRole.getRole_name());
+        appRoleDetails.setPolicies(appRole.getPolicies());
+        appRoleDetails.setBind_secret_id(appRole.isBind_secret_id());
+        appRoleDetails.setSecret_id_num_uses(appRole.getSecret_id_num_uses());
+        appRoleDetails.setSecret_id_ttl(appRole.getSecret_id_ttl());
+        appRoleDetails.setToken_num_uses(appRole.getToken_num_uses());
+        appRoleDetails.setToken_ttl(appRole.getToken_ttl());
+        appRoleDetails.setToken_max_ttl(appRole.getToken_max_ttl());
 		appRoleDetails.setRole_id(roleId);
 		appRoleDetails.setAppRoleMetadata(approleMetadata);
 		if (!CollectionUtils.isEmpty(accessorIds)) {
@@ -3715,7 +3877,14 @@ public class AppRoleServiceTest {
                 Mockito.any())).thenReturn(accessorIdResponse);
 
         AppRoleDetails appRoleDetails = new AppRoleDetails();
-        appRoleDetails.setAppRole(appRole);
+        appRoleDetails.setRole_name(appRole.getRole_name());
+        appRoleDetails.setPolicies(appRole.getPolicies());
+        appRoleDetails.setBind_secret_id(appRole.isBind_secret_id());
+        appRoleDetails.setSecret_id_num_uses(appRole.getSecret_id_num_uses());
+        appRoleDetails.setSecret_id_ttl(appRole.getSecret_id_ttl());
+        appRoleDetails.setToken_num_uses(appRole.getToken_num_uses());
+        appRoleDetails.setToken_ttl(appRole.getToken_ttl());
+        appRoleDetails.setToken_max_ttl(appRole.getToken_max_ttl());
         appRoleDetails.setRole_id(roleId);
         appRoleDetails.setAppRoleMetadata(approleMetadata);
         if (!CollectionUtils.isEmpty(accessorIds)) {
@@ -3812,7 +3981,14 @@ public class AppRoleServiceTest {
         when(reqProcessor.process("/auth/approle/role/accessors/list", "{\"role_name\":\""+role_name+"\"}",userDetails.getSelfSupportToken())).thenReturn(accessorIdResponse);
         
 		AppRoleDetails appRoleDetails = new AppRoleDetails();
-		appRoleDetails.setAppRole(appRole);
+        appRoleDetails.setRole_name(appRole.getRole_name());
+        appRoleDetails.setPolicies(appRole.getPolicies());
+        appRoleDetails.setBind_secret_id(appRole.isBind_secret_id());
+        appRoleDetails.setSecret_id_num_uses(appRole.getSecret_id_num_uses());
+        appRoleDetails.setSecret_id_ttl(appRole.getSecret_id_ttl());
+        appRoleDetails.setToken_num_uses(appRole.getToken_num_uses());
+        appRoleDetails.setToken_ttl(appRole.getToken_ttl());
+        appRoleDetails.setToken_max_ttl(appRole.getToken_max_ttl());
 		appRoleDetails.setRole_id(roleId);
 		appRoleDetails.setAppRoleMetadata(approleMetadata);
 		if (!CollectionUtils.isEmpty(accessorIds)) {
@@ -3908,7 +4084,14 @@ public class AppRoleServiceTest {
                 .thenReturn(accessorIdResponse);
 
         AppRoleDetails appRoleDetails = new AppRoleDetails();
-        appRoleDetails.setAppRole(appRole);
+        appRoleDetails.setRole_name(appRole.getRole_name());
+        appRoleDetails.setPolicies(appRole.getPolicies());
+        appRoleDetails.setBind_secret_id(appRole.isBind_secret_id());
+        appRoleDetails.setSecret_id_num_uses(appRole.getSecret_id_num_uses());
+        appRoleDetails.setSecret_id_ttl(appRole.getSecret_id_ttl());
+        appRoleDetails.setToken_num_uses(appRole.getToken_num_uses());
+        appRoleDetails.setToken_ttl(appRole.getToken_ttl());
+        appRoleDetails.setToken_max_ttl(appRole.getToken_max_ttl());
         appRoleDetails.setRole_id(roleId);
         appRoleDetails.setAppRoleMetadata(approleMetadata);
         if (!CollectionUtils.isEmpty(accessorIds)) {
@@ -4047,7 +4230,14 @@ public class AppRoleServiceTest {
                 userDetails.getSelfSupportToken())).thenReturn(accessorIdResponse);
 
         AppRoleDetails appRoleDetails = new AppRoleDetails();
-        appRoleDetails.setAppRole(appRole);
+        appRoleDetails.setRole_name(appRole.getRole_name());
+        appRoleDetails.setPolicies(appRole.getPolicies());
+        appRoleDetails.setBind_secret_id(appRole.isBind_secret_id());
+        appRoleDetails.setSecret_id_num_uses(appRole.getSecret_id_num_uses());
+        appRoleDetails.setSecret_id_ttl(appRole.getSecret_id_ttl());
+        appRoleDetails.setToken_num_uses(appRole.getToken_num_uses());
+        appRoleDetails.setToken_ttl(appRole.getToken_ttl());
+        appRoleDetails.setToken_max_ttl(appRole.getToken_max_ttl());
         appRoleDetails.setRole_id(roleId);
         appRoleDetails.setAppRoleMetadata(approleMetadata);
         if (!CollectionUtils.isEmpty(accessorIds)) {
@@ -4142,7 +4332,14 @@ public class AppRoleServiceTest {
                 userDetails.getSelfSupportToken())).thenReturn(accessorIdResponse);
 
         AppRoleDetails appRoleDetails = new AppRoleDetails();
-        appRoleDetails.setAppRole(appRole);
+        appRoleDetails.setRole_name(appRole.getRole_name());
+        appRoleDetails.setPolicies(appRole.getPolicies());
+        appRoleDetails.setBind_secret_id(appRole.isBind_secret_id());
+        appRoleDetails.setSecret_id_num_uses(appRole.getSecret_id_num_uses());
+        appRoleDetails.setSecret_id_ttl(appRole.getSecret_id_ttl());
+        appRoleDetails.setToken_num_uses(appRole.getToken_num_uses());
+        appRoleDetails.setToken_ttl(appRole.getToken_ttl());
+        appRoleDetails.setToken_max_ttl(appRole.getToken_max_ttl());
         appRoleDetails.setRole_id(roleId);
         appRoleDetails.setAppRoleMetadata(approleMetadata);
         if (!CollectionUtils.isEmpty(accessorIds)) {
@@ -4235,7 +4432,14 @@ public class AppRoleServiceTest {
         when(reqProcessor.process("/auth/approle/role/accessors/list", "{\"role_name\":\""+role_name+"\"}",userDetails.getSelfSupportToken())).thenReturn(accessorIdResponse);
 
         AppRoleDetails appRoleDetails = new AppRoleDetails();
-        appRoleDetails.setAppRole(appRole);
+        appRoleDetails.setRole_name(appRole.getRole_name());
+        appRoleDetails.setPolicies(appRole.getPolicies());
+        appRoleDetails.setBind_secret_id(appRole.isBind_secret_id());
+        appRoleDetails.setSecret_id_num_uses(appRole.getSecret_id_num_uses());
+        appRoleDetails.setSecret_id_ttl(appRole.getSecret_id_ttl());
+        appRoleDetails.setToken_num_uses(appRole.getToken_num_uses());
+        appRoleDetails.setToken_ttl(appRole.getToken_ttl());
+        appRoleDetails.setToken_max_ttl(appRole.getToken_max_ttl());
         appRoleDetails.setRole_id(roleId);
         appRoleDetails.setAppRoleMetadata(approleMetadata);
         if (!CollectionUtils.isEmpty(accessorIds)) {
@@ -4334,7 +4538,14 @@ public class AppRoleServiceTest {
         when(reqProcessor.process("/auth/approle/role/accessors/list", "{\"role_name\":\""+role_name+"\"}",userDetails.getSelfSupportToken())).thenReturn(accessorIdResponse);
         
 		AppRoleDetails appRoleDetails = new AppRoleDetails();
-		appRoleDetails.setAppRole(appRole);
+        appRoleDetails.setRole_name(appRole.getRole_name());
+        appRoleDetails.setPolicies(appRole.getPolicies());
+        appRoleDetails.setBind_secret_id(appRole.isBind_secret_id());
+        appRoleDetails.setSecret_id_num_uses(appRole.getSecret_id_num_uses());
+        appRoleDetails.setSecret_id_ttl(appRole.getSecret_id_ttl());
+        appRoleDetails.setToken_num_uses(appRole.getToken_num_uses());
+        appRoleDetails.setToken_ttl(appRole.getToken_ttl());
+        appRoleDetails.setToken_max_ttl(appRole.getToken_max_ttl());
 		appRoleDetails.setRole_id(roleId);
 		appRoleDetails.setAppRoleMetadata(approleMetadata);
 		if (!CollectionUtils.isEmpty(accessorIds)) {

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/SelfSupportServiceTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/service/SelfSupportServiceTest.java
@@ -3790,16 +3790,23 @@ public class SelfSupportServiceTest {
         assertEquals(responseEntityExpected, responseEntity);
     }
     @Test
-    public void test_list_fail(){
+    public void test_listAppRoles_successfully(){
         String sampletok = "5PDrOhsy4ig8L3EpsJZSLAMg";
         UserDetails userDetails = getMockUser(false);
         String path = "users/safe1";
         String PATHSTR = "{\"path\":\"";
-        Response readResponse = getMockResponse(HttpStatus.OK, true, "{\"data\":{\"description\":\"My first safe\",\"name\":\"safe1\",\"owner\":\"youremail@yourcompany.com\",\"type\":\"\"}}");
+        AppRoleListObject appRoleListObject = new AppRoleListObject("role1", false);
+        AppRoleListObject appRoleListObject2 = new AppRoleListObject("role2", true);
+        AppRoleListObject appRoleListObject3 = new AppRoleListObject("role3", false);
+        List<AppRoleListObject> appRoleListObjects = new ArrayList<>();
+        appRoleListObjects.add(appRoleListObject);
+        appRoleListObjects.add(appRoleListObject2);
+        appRoleListObjects.add(appRoleListObject3);
+        ResponseEntity<List<AppRoleListObject>> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(appRoleListObjects);
 
-        when(reqProcessor.process("/auth/approles/rolesbyuser/list",PATHSTR+ path +"\"}",userDetails.getSelfSupportToken())).thenReturn(readResponse);
-        ResponseEntity<String>responseEntity= selfSupportService.listAppRoles(sampletok,userDetails, 10,0);
-
+        when(appRoleService.listAppRoles(sampletok, userDetails, 10, 0)).thenReturn(responseEntityExpected);
+        ResponseEntity<List<AppRoleListObject>> responseEntityActual = selfSupportService.listAppRoles(sampletok,userDetails, 10,0);
+        assertEquals(responseEntityActual, responseEntityExpected);
     }
     @Test
     public void test_readAppRoleRoleId_failure(){

--- a/tvaultapi/src/test/java/com/tmobile/cso/vault/api/v2/controller/SelfSupportControllerTest.java
+++ b/tvaultapi/src/test/java/com/tmobile/cso/vault/api/v2/controller/SelfSupportControllerTest.java
@@ -23,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.tmobile.cso.vault.api.model.*;
 import org.apache.commons.collections.CollectionUtils;
@@ -671,20 +672,16 @@ public class SelfSupportControllerTest {
     
     @Test
     public void test_listAppRoles() throws Exception {
-		String vaultToken = "5PDrOhsy4ig8L3EpsJZSLAMg";
-    	String role_id_response = "{\n" + 
-    			"  \"keys\": [\n" + 
-    			"    \"testapprole01\"\n" + 
-    			"  ]\n" + 
-    			"}";
-    	StringBuilder responseMessage = new StringBuilder(role_id_response);
-        ResponseEntity<String> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(responseMessage.toString());
-        when(selfSupportService.listAppRoles(eq(vaultToken), Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(responseEntityExpected);
+		String vaultTkn = "5PDrOhsy4ig8L3EpsJZSLAMg";
+        List<AppRoleListObject> appRoleListObjects = new ArrayList<>();
+        appRoleListObjects.add(new AppRoleListObject("somename", true));
+        ResponseEntity<List<AppRoleListObject>> responseEntityExpected = ResponseEntity.status(HttpStatus.OK).body(appRoleListObjects);
+        when(selfSupportService.listAppRoles(eq(vaultTkn), Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(responseEntityExpected);
         mockMvc.perform(MockMvcRequestBuilders.get("/v2/ss/approle")
-                .header("vault-token", vaultToken)
+                .header("vault-token", vaultTkn)
                 .header("Content-Type", "application/json;charset=UTF-8"))
         		.andExpect(status().isOk())
-        		.andExpect(content().string(containsString(responseMessage.toString())));
+        		.andExpect(content().string(containsString("somename")));
     }
 
     @Test

--- a/tvaultuiv2/src/components/AddAppRole/index.js
+++ b/tvaultuiv2/src/components/AddAppRole/index.js
@@ -143,10 +143,10 @@ const AddAppRole = (props) => {
       apiService
         .getExistingAppRole()
         .then((res) => {
-          if (res && res.data?.keys) {
+          if (res && res.data) {
             setLoader(false);
-            if (res.data.keys.length > 0) {
-              setMenu([...res.data.keys]);
+            if (res.data.length > 0) {
+              setMenu([...res.data.map(role => role.roleName)]);
             }
           }
         })

--- a/tvaultuiv2/src/views/private/vault-app-roles/CreateAppRole/index.js
+++ b/tvaultuiv2/src/views/private/vault-app-roles/CreateAppRole/index.js
@@ -486,6 +486,12 @@ const CreateAppRole = (props) => {
     }
   };
 
+  const onTransferKeyClicked = (e) => {
+    if (e.keyCode === 13 && e?.target?.value) {
+      e.preventDefault();
+    }
+  }
+
   const splitString = (val) => {
     return val.split('_').slice('2').join('_');
   };
@@ -1147,6 +1153,7 @@ const CreateAppRole = (props) => {
                         onChange={(e) => {
                           onNewOwnerChange(e);
                         }}
+                        onKeyDownClick={(e) => onTransferKeyClicked(e)}
                         placeholder={'Search by NTID, Email or Name'}
                         error={transferError}
                         helperText={transferError ? transferErrorMessage : ''}

--- a/tvaultuiv2/src/views/private/vault-app-roles/components/AppRolesDashboard/index.js
+++ b/tvaultuiv2/src/views/private/vault-app-roles/components/AppRolesDashboard/index.js
@@ -225,9 +225,10 @@ const AppRolesDashboard = () => {
         setResponse({ status: 'success' });
         const appRolesArr = [];
         if (res?.data?.keys) {
-          res.data.keys.map((item) => {
+          res.data.map((item) => {
             const appObj = {
-              name: item,
+              name: item.roleName,
+              isOwner: item.owner,
               admin,
             };
             return appRolesArr.push(appObj);
@@ -490,7 +491,7 @@ const AppRolesDashboard = () => {
         }
       >
         <ListItem
-          title={appRole.name}
+          title={appRole.isOwner ? appRole.name + ' 👑' : appRole.name}
           subTitle={appRole.date}
           flag={appRole.type}
           icon={appRoleIcon}


### PR DESCRIPTION
PR for adding UI indicator to show if the logged in user is the owner of a given AppRole at a glance. This makes it so navigating the AppRole dashboard page is much easier, because the user will know without having to edit the AppRole if they own it. Owners of AppRoles are the only people who can delete the role or change the ownership (full or shared). Also added a fix so that hitting the enter key on the AppRole transfer modal doesn't cause an error (just prevents default behavior). Also made it so the GET AppRole details API doesn't return multiple instances of the "sharedTo" field. To accomplish this I modified the AppRoleDetails object.